### PR TITLE
Fix FirebaseCore dependency in podspec

### DIFF
--- a/AppCheckCore.podspec
+++ b/AppCheckCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AppCheckCore'
-  s.version          = '10.13.0'
+  s.version          = '0.1.0-alpha.1'
   s.summary          = 'App Check Core SDK.'
 
   s.description      = <<-DESC
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.authors          = 'Google, Inc.'
 
   s.source           = {
-    :git => 'https://github.com/firebase/firebase-ios-sdk.git',
+    :git => 'https://github.com/google/app-check.git',
     :tag => 'CocoaPods-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
@@ -63,7 +63,7 @@ Pod::Spec.new do |s|
     ]
 
     unit_tests.resources = base_dir + 'Tests/Fixture/**/*'
-    unit_tests.dependency 'FirebaseCore', '~> 10.0'
+    unit_tests.dependency 'FirebaseCoreExtension', '~> 10.0'
     unit_tests.dependency 'OCMock'
     unit_tests.requires_app_host = true
   end
@@ -79,7 +79,6 @@ Pod::Spec.new do |s|
       base_dir + 'Tests/Integration/**/*.[mh]',
     ]
     integration_tests.resources = base_dir + 'Tests/Fixture/**/*'
-    integration_tests.dependency 'FirebaseCore', '~> 10.0'
     integration_tests.dependency 'FirebaseCoreExtension', '~> 10.0'
     integration_tests.requires_app_host = true
   end

--- a/AppCheckCore/Tests/Integration/GACDeviceCheckAPIServiceE2ETests.m
+++ b/AppCheckCore/Tests/Integration/GACDeviceCheckAPIServiceE2ETests.m
@@ -29,7 +29,6 @@
 
 #import "FBLPromise+Testing.h"
 
-#import <FirebaseCore/FirebaseCore.h>
 #import <FirebaseCoreExtension/FirebaseCoreInternal.h>
 
 #import "AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.h"

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
@@ -16,6 +16,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import <FirebaseCoreExtension/FirebaseCoreInternal.h>
 #import <OCMock/OCMock.h>
 #import "FBLPromise+Testing.h"
 
@@ -32,8 +33,6 @@
 #import "AppCheckCore/Sources/AppAttestProvider/Errors/GACAppAttestRejectionError.h"
 #import "AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 #import "AppCheckCore/Sources/Core/Errors/GACAppCheckHTTPError.h"
-
-#import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
 #import "AppCheckCore/Tests/Utils/AppCheckBackoffWrapperFake/GACAppCheckBackoffWrapperFake.h"
 

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
@@ -16,6 +16,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import <FirebaseCoreExtension/FirebaseCoreInternal.h>
 #import <OCMock/OCMock.h>
 #import "FBLPromise+Testing.h"
 
@@ -30,8 +31,6 @@
 #import "AppCheckCore/Tests/Unit/Utils/GACFixtureLoader.h"
 #import "AppCheckCore/Tests/Utils/Date/GACDateTestUtils.h"
 #import "AppCheckCore/Tests/Utils/URLSession/GACURLSessionOCMockStub.h"
-
-#import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
 static NSString *const kAPIKeyHeaderKey = @"X-Goog-Api-Key";
 static NSString *const kAPIKeyHeaderValue = @"Test-API-Key";

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckTests.m
@@ -16,6 +16,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import <FirebaseCoreExtension/FirebaseCoreInternal.h>
 #import <OCMock/OCMock.h>
 
 #import "FBLPromise+Testing.h"
@@ -31,8 +32,6 @@
 #import "AppCheckCore/Sources/Core/TokenRefresh/GACAppCheckTokenRefresher.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckToken.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckTokenDelegate.h"
-
-#import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
 // The FAC token value returned when an error occurs.
 static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";

--- a/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderTests.m
+++ b/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderTests.m
@@ -16,14 +16,13 @@
 
 #import <XCTest/XCTest.h>
 
+#import <FirebaseCoreExtension/FirebaseCoreInternal.h>
 #import <OCMock/OCMock.h>
 #import "FBLPromise+Testing.h"
 
 #import "AppCheckCore/Sources/DebugProvider/API/GACAppCheckDebugProviderAPIService.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckDebugProvider.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckToken.h"
-
-#import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
 static NSString *const kDebugTokenEnvKey = @"FIRAAppCheckDebugToken";
 static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";

--- a/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
@@ -16,6 +16,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import <FirebaseCoreExtension/FirebaseCoreInternal.h>
 #import <OCMock/OCMock.h>
 #import "FBLPromise+Testing.h"
 
@@ -29,8 +30,6 @@
 
 #import "AppCheckCore/Tests/Unit/Utils/GACFixtureLoader.h"
 #import "AppCheckCore/Tests/Utils/URLSession/GACURLSessionOCMockStub.h"
-
-#import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
 static NSString *const kResourceName = @"projects/project_id/apps/app_id";
 

--- a/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckProviderTests.m
+++ b/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckProviderTests.m
@@ -16,6 +16,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import <FirebaseCoreExtension/FirebaseCoreInternal.h>
 #import <OCMock/OCMock.h>
 #import "FBLPromise+Testing.h"
 
@@ -23,8 +24,6 @@
 #import "AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckTokenGenerator.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckToken.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACDeviceCheckProvider.h"
-
-#import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
 #import "AppCheckCore/Tests/Utils/AppCheckBackoffWrapperFake/GACAppCheckBackoffWrapperFake.h"
 


### PR DESCRIPTION
The App Check Core unit tests still have a dependency on Firebase Core (specifically, `FirebaseCoreExtension`). Updated the imports to framework-style `<>`, instead of `""`, since they are coming from the dependency rather than looking for a local path (different repo).

Updated the version from `10.13.0` to `0.1.0-alpha.1` to reflect the pre-release status.