### PR TITLE
Add code formatting infrastructure

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+BasedOnStyle: Google
+ColumnLimit: 100
+BinPackParameters: false
+AllowAllParametersOfDeclarationOnNextLine: true
+ObjCSpaceBeforeProtocolList: true
+SpacesInContainerLiterals: true
+PointerAlignment: Right
+AllowShortFunctionsOnASingleLine: None
+IncludeBlocks: Preserve

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,50 @@
+# macOS
+.DS_Store
+
+# Xcode
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+*.xccheckout
+profile
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+
+# Swift Package Manager
+.build
+Package.resolved
+
+# Mint package manager
+Mint
+
+# Vim
+*.swo
+*.swp
+*~
+
+# Bundler
+/.bundle
+/vendor
+
+# CocoaPods
+Pods/
+Podfile.lock
+*.xcworkspace
+
+# CocoaPods generate
+gen/
+
+# firebase-ios-sdk clone
+firebase-ios-sdk/
+
+# scripts link
+scripts

--- a/Mintfile
+++ b/Mintfile
@@ -1,0 +1,1 @@
+nicklockwood/SwiftFormat@0.51.12

--- a/setup-scripts.sh
+++ b/setup-scripts.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright 2021 Google LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+git clone \
+  --depth 1 \
+  --no-checkout \
+  https://github.com/firebase/firebase-ios-sdk.git \
+;
+cd firebase-ios-sdk
+git checkout master -- scripts
+cd ..
+ln -s firebase-ios-sdk/scripts scripts


### PR DESCRIPTION
- Added a script to clone `firebase-ios-sdk` and link to the `scripts` subdirectory (copied from GoogleUtilities [`setup-scripts.sh`](https://github.com/google/GoogleUtilities/blob/main/setup-scripts.sh)).
  - This allows the [`style.sh`](https://github.com/firebase/firebase-ios-sdk/blob/5a7af33c52b8048151bad5a8e96a25e136fcd6aa/scripts/style.sh) script to be used in this repo.
- Copied `.clang-format` and `Mintfile` from `firebase-ios-sdk`.
- Copied `.gitignore` from `GoogleUtilities`.