### PR TITLE
Update `PromisesObjC` and `GoogleUtilities` versions in Podspec

### DIFF
--- a/AppCheckCore.podspec
+++ b/AppCheckCore.podspec
@@ -43,8 +43,8 @@ Pod::Spec.new do |s|
   s.osx.weak_framework = 'DeviceCheck'
   s.tvos.weak_framework = 'DeviceCheck'
 
-  s.dependency 'PromisesObjC', '~> 2.3.1'
-  s.dependency 'GoogleUtilities/Environment', '~> 7.11.5'
+  s.dependency 'PromisesObjC', '~> 2.3'
+  s.dependency 'GoogleUtilities/Environment', '~> 7.11'
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/AppCheckCore.podspec
+++ b/AppCheckCore.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   tvos_deployment_target = '12.0'
   watchos_deployment_target = '6.0'
 
-  s.swift_version = '5.3'
+  s.swift_version = '5.7.1'
 
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target
@@ -43,8 +43,8 @@ Pod::Spec.new do |s|
   s.osx.weak_framework = 'DeviceCheck'
   s.tvos.weak_framework = 'DeviceCheck'
 
-  s.dependency 'PromisesObjC', '~> 2.1'
-  s.dependency 'GoogleUtilities/Environment', '~> 7.8'
+  s.dependency 'PromisesObjC', '~> 2.3.1'
+  s.dependency 'GoogleUtilities/Environment', '~> 7.11.5'
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',


### PR DESCRIPTION
Updated the `PromisesObjC` dependency to `~> 2.3` and `GoogleUtilities/Environment` to `~> 7.11` in `AppCheckCore.podspec`. These match the the version ranges specified in [`Package.swift`](https://github.com/google/app-check/blob/497173c09bba2c318dc569ec469b7d4e12937677/Package.swift#L31-L36).