### PR TITLE
Decrease minimum Swift version to 5.5

### DIFF
--- a/AppCheckCore.podspec
+++ b/AppCheckCore.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   tvos_deployment_target = '12.0'
   watchos_deployment_target = '6.0'
 
-  s.swift_version = '5.7.1'
+  s.swift_version = '5.5'
 
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7.1
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 // Copyright 2023 Google LLC


### PR DESCRIPTION
Decreased the minimum Swift version from `5.7.1` to `5.5` to support building in Xcode 13 on macOS 11.