### PR TITLE
Remove `FirebaseCoreExtension` dependency in tests

### DIFF
--- a/AppCheckCore.podspec
+++ b/AppCheckCore.podspec
@@ -78,7 +78,6 @@ Pod::Spec.new do |s|
       base_dir + 'Tests/Integration/**/*.[mh]',
     ]
     integration_tests.resources = base_dir + 'Tests/Fixture/**/*'
-    integration_tests.dependency 'FirebaseCoreExtension', '~> 10.0'
     integration_tests.requires_app_host = true
   end
 

--- a/AppCheckCore.podspec
+++ b/AppCheckCore.podspec
@@ -63,7 +63,6 @@ Pod::Spec.new do |s|
     ]
 
     unit_tests.resources = base_dir + 'Tests/Fixture/**/*'
-    unit_tests.dependency 'FirebaseCoreExtension', '~> 10.0'
     unit_tests.dependency 'OCMock'
     unit_tests.requires_app_host = true
   end
@@ -93,7 +92,6 @@ Pod::Spec.new do |s|
       base_dir + 'Tests/Unit/Swift/**/*.swift',
       base_dir + 'Tests/Unit/Swift/**/*.h',
     ]
-    swift_unit_tests.dependency 'FirebaseCore', '~> 10.0'
   end
 
 end

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
@@ -16,7 +16,6 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FirebaseCoreExtension/FirebaseCoreInternal.h>
 #import <OCMock/OCMock.h>
 #import "FBLPromise+Testing.h"
 
@@ -98,28 +97,6 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
   self.mockAppAttestService = nil;
   self.fakeBackoffWrapper = nil;
 }
-
-#pragma mark - Init tests
-
-#if !TARGET_OS_MACCATALYST
-// Keychain dependent logic require additional configuration on Catalyst (enabling Keychain
-// sharing). For now, keychain dependent tests are disabled for Catalyst.
-- (void)testInitWithValidApp {
-  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:@"app_id" GCMSenderID:@"sender_id"];
-  options.APIKey = @"api_key";
-  options.projectID = @"project_id";
-  FIRApp *app = [[FIRApp alloc] initInstanceWithName:@"testInitWithValidApp" options:options];
-  NSString *resourceName = [GACAppAttestProviderTests resourceNameFromApp:app];
-
-  XCTAssertNotNil([[GACAppAttestProvider alloc] initWithServiceName:app.name
-                                                       resourceName:resourceName
-                                                            baseURL:nil
-                                                             APIKey:app.options.APIKey
-                                                keychainAccessGroup:nil
-                                                         limitedUse:NO
-                                                       requestHooks:nil]);
-}
-#endif  // !TARGET_OS_MACCATALYST
 
 #pragma mark - Initial handshake (attestation)
 
@@ -1093,16 +1070,6 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
   OCMExpect([self.mockArtifactStorage setArtifact:nil forKey:@""])
       .andReturn([FBLPromise resolvedWith:nil]);
 }
-
-// TODO(andrewheard): Remove from generic App Check SDK.
-// FIREBASE_APP_CHECK_ONLY_BEGIN
-
-+ (NSString *)resourceNameFromApp:(FIRApp *)app {
-  return [NSString
-      stringWithFormat:@"projects/%@/apps/%@", app.options.projectID, app.options.googleAppID];
-}
-
-// FIREBASE_APP_CHECK_ONLY_END
 
 @end
 

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
@@ -16,7 +16,6 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FirebaseCoreExtension/FirebaseCoreInternal.h>
 #import <OCMock/OCMock.h>
 #import "FBLPromise+Testing.h"
 

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckTests.m
@@ -16,7 +16,6 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FirebaseCoreExtension/FirebaseCoreInternal.h>
 #import <OCMock/OCMock.h>
 
 #import "FBLPromise+Testing.h"

--- a/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderTests.m
+++ b/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderTests.m
@@ -16,7 +16,6 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FirebaseCoreExtension/FirebaseCoreInternal.h>
 #import <OCMock/OCMock.h>
 #import "FBLPromise+Testing.h"
 
@@ -58,21 +57,6 @@ typedef void (^GACAppCheckTokenValidationBlock)(GACAppCheckToken *_Nullable toke
   [self.processInfoMock stopMocking];
   self.processInfoMock = nil;
   [[NSUserDefaults standardUserDefaults] removeObjectForKey:kDebugTokenUserDefaultsKey];
-}
-
-#pragma mark - Initialization
-
-- (void)testInitWithValidApp {
-  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:@"app_id" GCMSenderID:@"sender_id"];
-  options.APIKey = @"api_key";
-  options.projectID = @"project_id";
-  FIRApp *app = [[FIRApp alloc] initInstanceWithName:@"testInitWithValidApp" options:options];
-
-  XCTAssertNotNil([[GACAppCheckDebugProvider alloc]
-      initWithServiceName:options.googleAppID
-             resourceName:[GACAppCheckDebugProviderTests resourceNameFromApp:app]
-                   APIKey:app.options.APIKey
-             requestHooks:nil]);
 }
 
 #pragma mark - Debug token generating/storing
@@ -166,15 +150,5 @@ typedef void (^GACAppCheckTokenValidationBlock)(GACAppCheckToken *_Nullable toke
 
   [self waitForExpectations:@[ expectation ] timeout:0.5];
 }
-
-// TODO(andrewheard): Remove from generic App Check SDK.
-// FIREBASE_APP_CHECK_ONLY_BEGIN
-
-+ (NSString *)resourceNameFromApp:(FIRApp *)app {
-  return [NSString
-      stringWithFormat:@"projects/%@/apps/%@", app.options.projectID, app.options.googleAppID];
-}
-
-// FIREBASE_APP_CHECK_ONLY_END
 
 @end

--- a/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
@@ -16,7 +16,6 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FirebaseCoreExtension/FirebaseCoreInternal.h>
 #import <OCMock/OCMock.h>
 #import "FBLPromise+Testing.h"
 

--- a/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckProviderTests.m
+++ b/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckProviderTests.m
@@ -16,7 +16,6 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FirebaseCoreExtension/FirebaseCoreInternal.h>
 #import <OCMock/OCMock.h>
 #import "FBLPromise+Testing.h"
 
@@ -70,19 +69,6 @@ GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
   self.fakeAPIService = nil;
   self.fakeTokenGenerator = nil;
   self.fakeBackoffWrapper = nil;
-}
-
-- (void)testInitWithValidApp {
-  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:@"app_id" GCMSenderID:@"sender_id"];
-  options.APIKey = @"api_key";
-  options.projectID = @"project_id";
-  FIRApp *app = [[FIRApp alloc] initInstanceWithName:@"testInitWithValidApp" options:options];
-
-  XCTAssertNotNil([[GACDeviceCheckProvider alloc]
-      initWithServiceName:app.name
-             resourceName:[GACDeviceCheckProviderTests resourceNameFromApp:app]
-                   APIKey:app.options.APIKey
-             requestHooks:nil]);
 }
 
 - (void)testGetTokenSuccess {
@@ -256,18 +242,6 @@ GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
   OCMVerifyAll(self.fakeAPIService);
   OCMVerifyAll(self.fakeTokenGenerator);
 }
-
-#pragma mark - Helpers
-
-// TODO(andrewheard): Remove from generic App Check SDK.
-// FIREBASE_APP_CHECK_ONLY_BEGIN
-
-+ (NSString *)resourceNameFromApp:(FIRApp *)app {
-  return [NSString
-      stringWithFormat:@"projects/%@/apps/%@", app.options.projectID, app.options.googleAppID];
-}
-
-// FIREBASE_APP_CHECK_ONLY_END
 
 @end
 

--- a/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -19,23 +19,24 @@
 import Foundation
 
 import AppCheckCore
-import FirebaseCore
 
 final class AppCheckAPITests {
   func usage() {
-    let app = FirebaseApp.app()!
-    let projectID = app.options.projectID!
-    let resourceName = "projects/\(projectID)/\(app.options.googleAppID)"
+    let serviceName = "AppCheckAPITests"
+    let resourceName = "projects/test-project-id/google-app-id"
+    let appGroupID = "TeamIDPrefix.com.google.appcheck"
+    let apiKey = "test-api-key"
 
     // MARK: - AppAttestProvider
 
-    #if TARGET_OS_IOS
-      if #available(iOS 14.0, *) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+      if #available(iOS 14.0, tvOS 15.0, watchOS 9.0, *) {
         // TODO(andrewheard): Add `requestHooks` in API tests.
         if let provider = AppCheckCoreAppAttestProvider(
-          storageID: app.name,
+          serviceName: serviceName,
           resourceName: resourceName,
-          apiKey: app.options.apiKey,
+          baseURL: nil,
+          apiKey: apiKey,
           keychainAccessGroup: nil,
           requestHooks: nil
         ) {
@@ -44,20 +45,18 @@ final class AppCheckAPITests {
           }
         }
       }
-    #endif // TARGET_OS_IOS
+    #endif // os(iOS) || os(tvOS) || os(watchOS)
 
-    // MARK: - AppCheck
-
-    guard let app = FirebaseApp.app() else { return }
+    // MARK: - AppCheckCore
 
     // Retrieving an AppCheck instance
     let appCheck = AppCheckCore(
-      serviceName: app.name,
+      serviceName: serviceName,
       resourceName: resourceName,
       appCheckProvider: DummyAppCheckProvider(),
       settings: DummyAppCheckSettings(),
       tokenDelegate: DummyAppCheckTokenDelegate(),
-      keychainAccessGroup: app.options.appGroupID
+      keychainAccessGroup: appGroupID
     )
 
     // Get token
@@ -86,9 +85,9 @@ final class AppCheckAPITests {
     // `AppCheckDebugProvider` initializer
     // TODO(andrewheard): Add `requestHooks` in API tests.
     let debugProvider = AppCheckCoreDebugProvider(
-      serviceName: app.name,
+      serviceName: serviceName,
       resourceName: resourceName,
-      apiKey: app.options.apiKey,
+      apiKey: apiKey,
       requestHooks: nil
     )
     // Get token
@@ -157,9 +156,9 @@ final class AppCheckAPITests {
       if #available(iOS 11.0, macOS 10.15, macCatalyst 13.0, tvOS 11.0, *) {
         // TODO(andrewheard): Add `requestHooks` in API tests.
         let deviceCheckProvider = AppCheckCoreDeviceCheckProvider(
-          serviceName: app.name,
+          serviceName: serviceName,
           resourceName: resourceName,
-          apiKey: app.options.apiKey,
+          apiKey: apiKey,
           requestHooks: nil
         )
         // Get token

--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,10 @@ let package = Package(
       url: "https://github.com/google/GoogleUtilities.git",
       "7.11.5" ..< "8.0.0"
     ),
+    .package(
+      url: "https://github.com/erikdoe/ocmock.git",
+      revision: "c5eeaa6dde7c308a5ce48ae4d4530462dd3a1110"
+    ),
   ],
   targets: [
     .target(name: "AppCheckCore",
@@ -53,7 +57,33 @@ let package = Package(
                 .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS, .appCheckVisionOS])
               ),
             ]),
-    // TODO(andrewheard): Add unit test targets after removing Firebase dependencies.
+    .testTarget(
+      name: "AppCheckCoreUnit",
+      dependencies: [
+        "AppCheckCore",
+        .product(name: "OCMock", package: "ocmock"),
+      ],
+      path: "AppCheckCore/Tests",
+      exclude: [
+        // Swift tests are in the target `AppCheckCoreUnitSwift` since mixed language targets are
+        // not supported (as of Xcode 14.3).
+        "Unit/Swift",
+      ],
+      resources: [
+        .process("Fixture"),
+      ],
+      cSettings: [
+        .headerSearchPath("../.."),
+      ]
+    ),
+    .testTarget(
+      name: "AppCheckCoreUnitSwift",
+      dependencies: ["AppCheckCore"],
+      path: "AppCheckCore/Tests/Unit/Swift",
+      cSettings: [
+        .headerSearchPath("../.."),
+      ]
+    ),
   ]
 )
 


### PR DESCRIPTION
Removed the dependency on `FirebaseCoreExtension` from `firebase-ios-sdk` in preparation for setting up CI workflows.