### PR TITLE
Fix App Attest and DeviceCheck API availability

### DIFF
--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckAvailability.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckAvailability.h
@@ -21,32 +21,15 @@
 
 #pragma mark - DeviceCheck
 
-// DeviceCheck availability was extended to watchOS in Xcode 14.
-#if defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
-
 // Targets where DeviceCheck framework is available to be used in preprocessor conditions.
 #define GAC_DEVICE_CHECK_SUPPORTED_TARGETS \
   TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_TV || TARGET_OS_WATCH
 
 // `DeviceCheckProvider` availability.
 #define GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY \
-  API_AVAILABLE(ios(11.0), macos(10.15), tvos(11.0), watchos(9.0))
-
-// TODO(ncooke3): Remove `#else` clause when Xcode 14 is the minimum supported Xcode.
-#else  // defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
-
-// Targets where DeviceCheck framework is available to be used in preprocessor conditions.
-#define GAC_DEVICE_CHECK_SUPPORTED_TARGETS TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_TV
-
-// `DeviceCheckProvider` availability.
-#define GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY \
-  API_AVAILABLE(ios(11.0), macos(10.15), tvos(11.0)) API_UNAVAILABLE(watchos)
-
-#endif  // defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
+  API_AVAILABLE(ios(11.0), macos(10.15), macCatalyst(13.0), tvos(11.0), watchos(9.0))
 
 #pragma mark - App Attest
-
-#if defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
 
 // Targets where `DCAppAttestService` is available to be used in preprocessor conditions.
 #define GAC_APP_ATTEST_SUPPORTED_TARGETS \
@@ -54,16 +37,4 @@
 
 // `AppAttestProvider` availability annotations
 #define GAC_APP_ATTEST_PROVIDER_AVAILABILITY \
-  API_AVAILABLE(macos(11.0), ios(14.0), tvos(15.0), watchos(9.0))
-
-// TODO(ncooke3): Remove `#else` clause when Xcode 14 is the minimum supported Xcode.
-#else  // defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
-
-// Targets where `DCAppAttestService` is available to be used in preprocessor conditions.
-#define GAC_APP_ATTEST_SUPPORTED_TARGETS TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_TV
-
-// `AppAttestProvider` availability annotations
-#define GAC_APP_ATTEST_PROVIDER_AVAILABILITY \
-  API_AVAILABLE(macos(11.0), ios(14.0), tvos(15.0)) API_UNAVAILABLE(watchos)
-
-#endif  // defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
+  API_AVAILABLE(ios(14.0), macos(11.3), macCatalyst(14.5), tvos(15.0), watchos(9.0))

--- a/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -29,23 +29,21 @@ final class AppCheckAPITests {
 
     // MARK: - AppAttestProvider
 
-    #if os(iOS) || os(tvOS) || os(watchOS)
-      if #available(iOS 14.0, tvOS 15.0, watchOS 9.0, *) {
-        // TODO(andrewheard): Add `requestHooks` in API tests.
-        if let provider = AppCheckCoreAppAttestProvider(
-          serviceName: serviceName,
-          resourceName: resourceName,
-          baseURL: nil,
-          apiKey: apiKey,
-          keychainAccessGroup: nil,
-          requestHooks: nil
-        ) {
-          provider.getToken { token, error in
-            // ...
-          }
+    if #available(iOS 14.0, macOS 11.3, macCatalyst 14.5, tvOS 15.0, watchOS 9.0, *) {
+      // TODO(andrewheard): Add `requestHooks` in API tests.
+      if let provider = AppCheckCoreAppAttestProvider(
+        serviceName: serviceName,
+        resourceName: resourceName,
+        baseURL: nil,
+        apiKey: apiKey,
+        keychainAccessGroup: nil,
+        requestHooks: nil
+      ) {
+        provider.getToken { token, error in
+          // ...
         }
       }
-    #endif // os(iOS) || os(tvOS) || os(watchOS)
+    }
 
     // MARK: - AppCheckCore
 


### PR DESCRIPTION
Ported the changes from https://github.com/firebase/firebase-ios-sdk/pull/11662 into AppCheckCore:

- Updated the `GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY` and `GAC_APP_ATTEST_PROVIDER_AVAILABILITY` API availability macros to reflect the set of supported platforms for DeviceCheck (iOS 11+, macOS 10.15+, macCatalyst 13+, tvOS 11+, watchOS 9+) and App Attest (iOS 14+, macOS 11.3+, macCatalyst 14.5+, tvOS 15+, watchOS 9+).
- Removed the extraneous check for the watchOS 9 SDK since Xcode 14 is the minimum supported by App Check.