### PR TITLE
Add generation of limited-use tokens with a TTL of 5 mins

### DIFF
--- a/AppCheckCore/Sources/AppAttestProvider/API/GACAppAttestAPIService.h
+++ b/AppCheckCore/Sources/AppAttestProvider/API/GACAppAttestAPIService.h
@@ -39,12 +39,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// artifact and an App Check token or rejected with an error.
 - (FBLPromise<GACAppAttestAttestationResponse *> *)attestKeyWithAttestation:(NSData *)attestation
                                                                       keyID:(NSString *)keyID
-                                                                  challenge:(NSData *)challenge;
+                                                                  challenge:(NSData *)challenge
+                                                                 limitedUse:(BOOL)limitedUse;
 
 /// Exchanges attestation data (artifact & assertion) and a challenge for a FAC token.
 - (FBLPromise<GACAppCheckToken *> *)getAppCheckTokenWithArtifact:(NSData *)artifact
                                                        challenge:(NSData *)challenge
-                                                       assertion:(NSData *)assertion;
+                                                       assertion:(NSData *)assertion
+                                                      limitedUse:(BOOL)limitedUse;
 
 @end
 
@@ -60,10 +62,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// network requests to the App Check backend.
 /// @param resourceName The name of the resource protected by App Check; for a Firebase App this is
 /// "projects/{project_id}/apps/{app_id}".
-/// @param limitedUse If YES, forces a short-lived token with a 5 minute TTL.
 - (instancetype)initWithAPIService:(id<GACAppCheckAPIServiceProtocol>)APIService
-                      resourceName:(NSString *)resourceName
-                        limitedUse:(BOOL)limitedUse NS_DESIGNATED_INITIALIZER;
+                      resourceName:(NSString *)resourceName NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/AppCheckCore/Sources/AppAttestProvider/API/GACAppAttestAPIService.h
+++ b/AppCheckCore/Sources/AppAttestProvider/API/GACAppAttestAPIService.h
@@ -55,9 +55,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Default initializer.
 ///
-/// TODO(andrewheard): Remove or refactor the `limitedUse` parameter from this constructor when the
-/// short-lived (limited-use) token feature is fully implemented.
-///
 /// @param APIService An instance implementing `GACAppCheckAPIServiceProtocol` to be used to send
 /// network requests to the App Check backend.
 /// @param resourceName The name of the resource protected by App Check; for a Firebase App this is

--- a/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -173,8 +173,7 @@ NS_ASSUME_NONNULL_BEGIN
                                            requestHooks:requestHooks];
 
   GACAppAttestAPIService *appAttestAPIService =
-      [[GACAppAttestAPIService alloc] initWithAPIService:APIService
-                                            resourceName:resourceName];
+      [[GACAppAttestAPIService alloc] initWithAPIService:APIService resourceName:resourceName];
 
   GACAppAttestArtifactStorage *artifactStorage =
       [[GACAppAttestArtifactStorage alloc] initWithKeySuffix:storageKeySuffix

--- a/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -174,8 +174,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   GACAppAttestAPIService *appAttestAPIService =
       [[GACAppAttestAPIService alloc] initWithAPIService:APIService
-                                            resourceName:resourceName
-                                              limitedUse:limitedUse];
+                                            resourceName:resourceName];
 
   GACAppAttestArtifactStorage *artifactStorage =
       [[GACAppAttestArtifactStorage alloc] initWithKeySuffix:storageKeySuffix

--- a/AppCheckCore/Sources/Core/GACAppCheck.m
+++ b/AppCheckCore/Sources/Core/GACAppCheck.m
@@ -215,7 +215,7 @@ typedef void (^GACAppCheckTokenHandler)(id<GACAppCheckTokenProtocol> _Nullable t
   return
       [FBLPromise wrapObjectOrErrorCompletion:^(
                       FBLPromiseObjectOrErrorCompletion _Nonnull handler) {
-        [self.appCheckProvider getTokenWithCompletion:handler];
+        [self.appCheckProvider getLimitedUseTokenWithCompletion:handler];
       }].then(^id _Nullable(GACAppCheckToken *_Nullable token) {
         return token;
       });

--- a/AppCheckCore/Sources/DebugProvider/API/GACAppCheckDebugProviderAPIService.h
+++ b/AppCheckCore/Sources/DebugProvider/API/GACAppCheckDebugProviderAPIService.h
@@ -24,7 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol GACAppCheckDebugProviderAPIServiceProtocol <NSObject>
 
-- (FBLPromise<GACAppCheckToken *> *)appCheckTokenWithDebugToken:(NSString *)debugToken;
+- (FBLPromise<GACAppCheckToken *> *)appCheckTokenWithDebugToken:(NSString *)debugToken
+                                                     limitedUse:(BOOL)limitedUse;
 
 @end
 

--- a/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m
+++ b/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m
@@ -119,6 +119,12 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
       });
 }
 
+- (void)getLimitedUseTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable,
+                                                   NSError *_Nullable))handler {
+  // TODO(andrewheard): Add support for generating limited-use tokens with a 5-minute TTL.
+  [self getTokenWithCompletion:handler];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m
+++ b/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m
@@ -101,11 +101,24 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
 
 - (void)getTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable token,
                                          NSError *_Nullable error))handler {
+  [self getTokenWithLimitedUse:NO completion:handler];
+}
+
+- (void)getLimitedUseTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable,
+                                                   NSError *_Nullable))handler {
+  [self getTokenWithLimitedUse:YES completion:handler];
+}
+
+#pragma mark - Internal
+
+- (void)getTokenWithLimitedUse:(BOOL)limitedUse
+                    completion:(void (^)(GACAppCheckToken *_Nullable token,
+                                         NSError *_Nullable error))handler {
   [FBLPromise do:^NSString * {
     return [self currentDebugToken];
   }]
       .then(^FBLPromise<GACAppCheckToken *> *(NSString *debugToken) {
-        return [self.APIService appCheckTokenWithDebugToken:debugToken];
+        return [self.APIService appCheckTokenWithDebugToken:debugToken limitedUse:limitedUse];
       })
       .then(^id(GACAppCheckToken *appCheckToken) {
         handler(appCheckToken, nil);
@@ -117,12 +130,6 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
         GACAppCheckLogDebug(GACLoggerAppCheckMessageDebugProviderFailedExchange, logMessage);
         handler(nil, error);
       });
-}
-
-- (void)getLimitedUseTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable,
-                                                   NSError *_Nullable))handler {
-  // TODO(andrewheard): Add support for generating limited-use tokens with a 5-minute TTL.
-  [self getTokenWithCompletion:handler];
 }
 
 @end

--- a/AppCheckCore/Sources/DeviceCheckProvider/API/GACDeviceCheckAPIService.h
+++ b/AppCheckCore/Sources/DeviceCheckProvider/API/GACDeviceCheckAPIService.h
@@ -24,7 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol GACDeviceCheckAPIServiceProtocol <NSObject>
 
-- (FBLPromise<GACAppCheckToken *> *)appCheckTokenWithDeviceToken:(NSData *)deviceToken;
+- (FBLPromise<GACAppCheckToken *> *)appCheckTokenWithDeviceToken:(NSData *)deviceToken
+                                                      limitedUse:(BOOL)limitedUse;
 
 @end
 

--- a/AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
+++ b/AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
@@ -106,6 +106,14 @@ NS_ASSUME_NONNULL_BEGIN
       });
 }
 
+- (void)getLimitedUseTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable,
+                                                   NSError *_Nullable))handler {
+  // TODO(andrewheard): Add support for generating limited-use tokens with a 5-minute TTL.
+  [self getTokenWithCompletion:handler];
+}
+
+#pragma mark - Internal
+
 - (FBLPromise<GACAppCheckToken *> *)getTokenPromise {
   // Get DeviceCheck token
   return [self deviceToken]

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckProvider.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckProvider.h
@@ -24,17 +24,23 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param request The request that is about to be sent.
 typedef void (^GACAppCheckAPIRequestHook)(NSMutableURLRequest *request);
 
-/// Defines the methods required to be implemented by a specific Firebase App Check
-/// provider.
+/// Defines the methods required to be implemented by a specific App Check provider.
 NS_SWIFT_NAME(AppCheckCoreProvider)
 @protocol GACAppCheckProvider <NSObject>
 
-/// Returns a new Firebase App Check token.
+/// Returns a new App Check token.
 /// @param handler The completion handler. Make sure to call the handler with either a token
 /// or an error.
 - (void)getTokenWithCompletion:
     (void (^)(GACAppCheckToken *_Nullable token, NSError *_Nullable error))handler
     NS_SWIFT_NAME(getToken(completion:));
+
+/// Returns a new App Check token suitable for consumption in a limited-use scenario.
+/// @param handler The completion handler. Make sure to call the handler with either a token
+/// or an error.
+- (void)getLimitedUseTokenWithCompletion:
+    (void (^)(GACAppCheckToken *_Nullable token, NSError *_Nullable error))handler
+    NS_SWIFT_NAME(getLimitedUseToken(completion:));
 
 @end
 

--- a/AppCheckCore/Tests/Integration/GACDeviceCheckAPIServiceE2ETests.m
+++ b/AppCheckCore/Tests/Integration/GACDeviceCheckAPIServiceE2ETests.m
@@ -67,7 +67,7 @@ static NSString *const kResourceName = @"projects/test-project-id/google-app-id"
 // TODO: Re-enable the test once secret with "GoogleService-Info.plist" is configured.
 - (void)temporaryDisabled_testAppCheckTokenSuccess {
   __auto_type appCheckPromise =
-      [self.deviceCheckAPIService appCheckTokenWithDeviceToken:[NSData data]];
+      [self.deviceCheckAPIService appCheckTokenWithDeviceToken:[NSData data] limitedUse:NO];
 
   XCTAssert(FBLWaitForPromisesWithTimeout(20));
 

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestAPIServiceTests.m
@@ -53,8 +53,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   OCMStub([self.mockAPIService baseURL]).andReturn(kBaseURL);
 
   self.appAttestAPIService = [[GACAppAttestAPIService alloc] initWithAPIService:self.mockAPIService
-                                                                   resourceName:kResourceName
-                                                                     limitedUse:NO];
+                                                                   resourceName:kResourceName];
 }
 
 - (void)tearDown {
@@ -229,7 +228,8 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   // 3. Send request.
   __auto_type promise = [self.appAttestAPIService getAppCheckTokenWithArtifact:artifact
                                                                      challenge:challenge
-                                                                     assertion:assertion];
+                                                                     assertion:assertion
+                                                                    limitedUse:NO];
   // 4. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
 
@@ -267,7 +267,8 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   // 3. Send request.
   __auto_type promise = [self.appAttestAPIService getAppCheckTokenWithArtifact:artifact
                                                                      challenge:challenge
-                                                                     assertion:assertion];
+                                                                     assertion:assertion
+                                                                    limitedUse:NO];
   // 4. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
 
@@ -302,7 +303,8 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   // 3. Send request.
   __auto_type promise = [self.appAttestAPIService getAppCheckTokenWithArtifact:artifact
                                                                      challenge:challenge
-                                                                     assertion:assertion];
+                                                                     assertion:assertion
+                                                                    limitedUse:NO];
   // 4. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
 
@@ -337,7 +339,8 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   // 3. Send request.
   __auto_type promise = [self.appAttestAPIService attestKeyWithAttestation:attestation
                                                                      keyID:keyID
-                                                                 challenge:challenge];
+                                                                 challenge:challenge
+                                                                limitedUse:NO];
 
   // 4. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
@@ -374,7 +377,8 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   // 2. Send request.
   __auto_type promise = [self.appAttestAPIService attestKeyWithAttestation:attestation
                                                                      keyID:keyID
-                                                                 challenge:challenge];
+                                                                 challenge:challenge
+                                                                limitedUse:NO];
 
   // 3. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
@@ -408,7 +412,8 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   // 3. Send request.
   __auto_type promise = [self.appAttestAPIService attestKeyWithAttestation:attestation
                                                                      keyID:keyID
-                                                                 challenge:challenge];
+                                                                 challenge:challenge
+                                                                limitedUse:NO];
 
   // 4. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestAPIServiceTests.m
@@ -202,6 +202,14 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
 #pragma mark - Assertion request
 
 - (void)testGetAppCheckTokenSuccess {
+  [self testGetAppCheckTokenSuccessWithLimitedUse:NO];
+}
+
+- (void)testGetAppCheckTokenSuccessWithLimitedUse {
+  [self testGetAppCheckTokenSuccessWithLimitedUse:YES];
+}
+
+- (void)testGetAppCheckTokenSuccessWithLimitedUse:(BOOL)limitedUse {
   NSData *artifact = [self generateRandomData];
   NSData *challenge = [self generateRandomData];
   NSData *assertion = [self generateRandomData];
@@ -217,6 +225,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   [self expectTokenAPIRequestWithArtifact:artifact
                                 challenge:challenge
                                 assertion:assertion
+                               limitedUse:limitedUse
                                  response:validAPIResponse
                                     error:nil];
   // 2.2. Return token from parsed response.
@@ -229,7 +238,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   __auto_type promise = [self.appAttestAPIService getAppCheckTokenWithArtifact:artifact
                                                                      challenge:challenge
                                                                      assertion:assertion
-                                                                    limitedUse:NO];
+                                                                    limitedUse:limitedUse];
   // 4. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
 
@@ -261,6 +270,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   [self expectTokenAPIRequestWithArtifact:artifact
                                 challenge:challenge
                                 assertion:assertion
+                               limitedUse:NO
                                  response:validAPIResponse
                                     error:networkError];
 
@@ -295,6 +305,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   [self expectTokenAPIRequestWithArtifact:artifact
                                 challenge:challenge
                                 assertion:assertion
+                               limitedUse:NO
                                  response:validAPIResponse
                                     error:nil];
   // 2.2. Return token from parsed response.
@@ -318,6 +329,14 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
 #pragma mark - Attestation request
 
 - (void)testAttestKeySuccess {
+  [self testAttestKeySuccessWithLimitedUse:NO];
+}
+
+- (void)testAttestKeySuccessWithLimitedUse {
+  [self testAttestKeySuccessWithLimitedUse:YES];
+}
+
+- (void)testAttestKeySuccessWithLimitedUse:(BOOL)limitedUse {
   NSData *attestation = [self generateRandomData];
   NSData *challenge = [self generateRandomData];
   NSString *keyID = [NSUUID UUID].UUIDString;
@@ -333,6 +352,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   [self expectAttestAPIRequestWithAttestation:attestation
                                         keyID:keyID
                                     challenge:challenge
+                                   limitedUse:limitedUse
                                      response:validAPIResponse
                                         error:nil];
 
@@ -340,7 +360,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   __auto_type promise = [self.appAttestAPIService attestKeyWithAttestation:attestation
                                                                      keyID:keyID
                                                                  challenge:challenge
-                                                                limitedUse:NO];
+                                                                limitedUse:limitedUse];
 
   // 4. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
@@ -371,6 +391,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   [self expectAttestAPIRequestWithAttestation:attestation
                                         keyID:keyID
                                     challenge:challenge
+                                   limitedUse:NO
                                      response:nil
                                         error:networkError];
 
@@ -406,6 +427,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   [self expectAttestAPIRequestWithAttestation:attestation
                                         keyID:keyID
                                     challenge:challenge
+                                   limitedUse:NO
                                      response:validAPIResponse
                                         error:nil];
 
@@ -471,6 +493,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
 - (void)expectTokenAPIRequestWithArtifact:(NSData *)attestation
                                 challenge:(NSData *)challenge
                                 assertion:(NSData *)assertion
+                               limitedUse:(BOOL)limitedUse
                                  response:(nullable GULURLSessionDataResponse *)response
                                     error:(nullable NSError *)error {
   id URLValidationArg = [self URLValidationArgumentWithCustomMethod:@"exchangeAppAttestAssertion"];
@@ -501,6 +524,11 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
     // Validate assertion field.
     NSString *base64EncodedAssertion = decodedData[@"assertion"];
     XCTAssert([base64EncodedAssertion isKindOfClass:[NSString class]]);
+
+    // Validate limited-use field.
+    NSNumber *decodedLimitedUse = decodedData[@"limited_use"];
+    XCTAssertNotNil(decodedLimitedUse);
+    XCTAssertEqualObjects(decodedLimitedUse, @(limitedUse));
 
     NSData *decodedAssertion = [[NSData alloc] initWithBase64EncodedString:base64EncodedAssertion
                                                                    options:0];
@@ -537,6 +565,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
 - (void)expectAttestAPIRequestWithAttestation:(NSData *)attestation
                                         keyID:(NSString *)keyID
                                     challenge:(NSData *)challenge
+                                   limitedUse:(BOOL)limitedUse
                                      response:(nullable GULURLSessionDataResponse *)response
                                         error:(nullable NSError *)error {
   id URLValidationArg =
@@ -568,6 +597,11 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
     // Validate key ID field.
     NSString *keyIDField = decodedData[@"key_id"];
     XCTAssert([base64EncodedAttestation isKindOfClass:[NSString class]]);
+
+    // Validate limited-use field.
+    NSNumber *decodedLimitedUse = decodedData[@"limited_use"];
+    XCTAssertNotNil(decodedLimitedUse);
+    XCTAssertEqualObjects(decodedLimitedUse, @(limitedUse));
 
     XCTAssertEqualObjects(keyIDField, keyID);
 

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
@@ -127,7 +127,9 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
                                completionHandler:OCMOCK_ANY]);
   OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
                                                     keyID:OCMOCK_ANY
-                                                challenge:OCMOCK_ANY]);
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:NO])
+      .ignoringNonObjectArgs();
 
   // 3. Call get token.
   XCTestExpectation *completionExpectation =
@@ -193,8 +195,13 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
       [[GACAppAttestAttestationResponse alloc] initWithArtifact:artifactData token:FACToken];
   OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData
                                                     keyID:generatedKeyID
-                                                challenge:self.randomChallenge])
+                                                challenge:self.randomChallenge
+                                               limitedUse:NO])
       .andReturn([FBLPromise resolvedWith:attestKeyResponse]);
+  OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
+                                                    keyID:OCMOCK_ANY
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:YES]);
 
   // 8. Expect the artifact received from Firebase backend to be saved.
   OCMExpect([self.mockArtifactStorage setArtifact:artifactData forKey:generatedKeyID])
@@ -267,8 +274,13 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
       [[GACAppAttestAttestationResponse alloc] initWithArtifact:artifactData token:FACToken];
   OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData
                                                     keyID:existingKeyID
-                                                challenge:self.randomChallenge])
+                                                challenge:self.randomChallenge
+                                               limitedUse:NO])
       .andReturn([FBLPromise resolvedWith:attestKeyResponse]);
+  OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
+                                                    keyID:OCMOCK_ANY
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:YES]);
 
   // 9. Expect the artifact received from Firebase backend to be saved.
   OCMExpect([self.mockArtifactStorage setArtifact:artifactData forKey:existingKeyID])
@@ -326,7 +338,9 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
                                completionHandler:OCMOCK_ANY]);
   OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
                                                     keyID:OCMOCK_ANY
-                                                challenge:OCMOCK_ANY]);
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:NO])
+      .ignoringNonObjectArgs();
 
   // 6. Call get token.
   XCTestExpectation *completionExpectation =
@@ -384,7 +398,9 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
   // 6. Don't exchange API request.
   OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
                                                     keyID:OCMOCK_ANY
-                                                challenge:OCMOCK_ANY]);
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:NO])
+      .ignoringNonObjectArgs();
 
   // 7. Call get token.
   XCTestExpectation *completionExpectation =
@@ -443,8 +459,13 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
                                            userInfo:nil];
   OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData
                                                     keyID:existingKeyID
-                                                challenge:self.randomChallenge])
+                                                challenge:self.randomChallenge
+                                               limitedUse:NO])
       .andReturn([self rejectedPromiseWithError:exchangeError]);
+  OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
+                                                    keyID:OCMOCK_ANY
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:YES]);
 
   // 7. Call get token.
   XCTestExpectation *completionExpectation =
@@ -483,8 +504,13 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
   GACAppCheckHTTPError *APIError = [self attestationRejectionHTTPError];
   OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData1
                                                     keyID:keyID1
-                                                challenge:self.randomChallenge])
+                                                challenge:self.randomChallenge
+                                               limitedUse:NO])
       .andReturn([self rejectedPromiseWithError:APIError]);
+  OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
+                                                    keyID:OCMOCK_ANY
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:YES]);
 
   // 4. Stored attestation to be reset.
   [self expectAttestationReset];
@@ -502,8 +528,13 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
       [[GACAppAttestAttestationResponse alloc] initWithArtifact:artifactData token:FACToken];
   OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData2
                                                     keyID:keyID2
-                                                challenge:self.randomChallenge])
+                                                challenge:self.randomChallenge
+                                               limitedUse:NO])
       .andReturn([FBLPromise resolvedWith:attestKeyResponse]);
+  OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
+                                                    keyID:OCMOCK_ANY
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:YES]);
 
   // 7. Expect the artifact received from Firebase backend to be saved.
   OCMExpect([self.mockArtifactStorage setArtifact:artifactData forKey:keyID2])
@@ -540,8 +571,13 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
   GACAppCheckHTTPError *APIError = [self attestationRejectionHTTPError];
   OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData1
                                                     keyID:keyID1
-                                                challenge:self.randomChallenge])
+                                                challenge:self.randomChallenge
+                                               limitedUse:NO])
       .andReturn([self rejectedPromiseWithError:APIError]);
+  OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
+                                                    keyID:OCMOCK_ANY
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:YES]);
 
   // 4. Stored attestation to be reset.
   [self expectAttestationReset];
@@ -554,8 +590,13 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
   // 6. Expect exchange request to be sent.
   OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData2
                                                     keyID:keyID2
-                                                challenge:self.randomChallenge])
+                                                challenge:self.randomChallenge
+                                               limitedUse:NO])
       .andReturn([self rejectedPromiseWithError:APIError]);
+  OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
+                                                    keyID:OCMOCK_ANY
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:YES]);
 
   // 7. Stored attestation to be reset.
   [self expectAttestationReset];
@@ -612,7 +653,9 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
   // 6. Don't expect assertion request to be sent.
   OCMReject([self.mockAPIService getAppCheckTokenWithArtifact:OCMOCK_ANY
                                                     challenge:OCMOCK_ANY
-                                                    assertion:OCMOCK_ANY]);
+                                                    assertion:OCMOCK_ANY
+                                                   limitedUse:NO])
+      .ignoringNonObjectArgs();
 
   // 7. Call get token.
   XCTestExpectation *completionExpectation =
@@ -663,7 +706,9 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
   // 6. Don't expect assertion request to be sent.
   OCMReject([self.mockAPIService getAppCheckTokenWithArtifact:OCMOCK_ANY
                                                     challenge:OCMOCK_ANY
-                                                    assertion:OCMOCK_ANY]);
+                                                    assertion:OCMOCK_ANY
+                                                   limitedUse:NO])
+      .ignoringNonObjectArgs();
 
   // 7. Call get token.
   XCTestExpectation *completionExpectation =
@@ -715,8 +760,13 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
                       userInfo:nil];
   OCMExpect([self.mockAPIService getAppCheckTokenWithArtifact:storedArtifact
                                                     challenge:self.randomChallenge
-                                                    assertion:assertion])
+                                                    assertion:assertion
+                                                   limitedUse:NO])
       .andReturn([self rejectedPromiseWithError:tokenExchangeError]);
+  OCMReject([self.mockAPIService getAppCheckTokenWithArtifact:OCMOCK_ANY
+                                                    challenge:OCMOCK_ANY
+                                                    assertion:OCMOCK_ANY
+                                                   limitedUse:YES]);
 
   // 7. Call get token.
   XCTestExpectation *completionExpectation =
@@ -773,8 +823,13 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
                                                         expirationDate:[NSDate date]];
   OCMExpect([self.mockAPIService getAppCheckTokenWithArtifact:storedArtifact
                                                     challenge:self.randomChallenge
-                                                    assertion:assertion])
+                                                    assertion:assertion
+                                                   limitedUse:NO])
       .andReturn([FBLPromise resolvedWith:FACToken]);
+  OCMReject([self.mockAPIService getAppCheckTokenWithArtifact:OCMOCK_ANY
+                                                    challenge:OCMOCK_ANY
+                                                    assertion:OCMOCK_ANY
+                                                   limitedUse:YES]);
 
   // 7. Call get token several times.
   NSInteger callsCount = 10;
@@ -847,8 +902,13 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
   // 6.2. Stub assertion request.
   OCMExpect([self.mockAPIService getAppCheckTokenWithArtifact:storedArtifact
                                                     challenge:self.randomChallenge
-                                                    assertion:assertion])
+                                                    assertion:assertion
+                                                   limitedUse:NO])
       .andReturn(assertionRequestPromise);
+  OCMReject([self.mockAPIService getAppCheckTokenWithArtifact:OCMOCK_ANY
+                                                    challenge:OCMOCK_ANY
+                                                    assertion:OCMOCK_ANY
+                                                   limitedUse:YES]);
   // 6.3. Create an expected error to be rejected with later.
   NSError *assertionRequestError = [NSError errorWithDomain:self.name code:0 userInfo:nil];
 
@@ -906,7 +966,9 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
                                completionHandler:OCMOCK_ANY]);
   OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
                                                     keyID:OCMOCK_ANY
-                                                challenge:OCMOCK_ANY]);
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:NO])
+      .ignoringNonObjectArgs();
 
   // 3. Call get token.
   XCTestExpectation *completionExpectation =
@@ -1001,8 +1063,13 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
                                                         expirationDate:[NSDate date]];
   OCMExpect([self.mockAPIService getAppCheckTokenWithArtifact:storedArtifact
                                                     challenge:self.randomChallenge
-                                                    assertion:assertion])
+                                                    assertion:assertion
+                                                   limitedUse:NO])
       .andReturn([FBLPromise resolvedWith:FACToken]);
+  OCMReject([self.mockAPIService getAppCheckTokenWithArtifact:OCMOCK_ANY
+                                                    challenge:OCMOCK_ANY
+                                                    assertion:OCMOCK_ANY
+                                                   limitedUse:YES]);
 
   // 7. Call get token.
   XCTestExpectation *completionExpectation =

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckTests.m
@@ -344,7 +344,7 @@ static NSString *const kAppGroupID = @"app_group_id";
   // 2. Expect token requested from app check provider.
   GACAppCheckToken *expectedToken = [self validToken];
   id completionArg = [OCMArg invokeBlockWithArgs:expectedToken, [NSNull null], nil];
-  OCMExpect([self.mockAppCheckProvider getTokenWithCompletion:completionArg]);
+  OCMExpect([self.mockAppCheckProvider getLimitedUseTokenWithCompletion:completionArg]);
 
   // 3. Don't expect token requested from storage.
   OCMReject([self.mockStorage setToken:expectedToken]);
@@ -373,7 +373,7 @@ static NSString *const kAppGroupID = @"app_group_id";
   // 2. Expect error when requesting token from app check provider.
   NSError *providerError = [GACAppCheckErrorUtil keychainErrorWithError:[self internalError]];
   id completionArg = [OCMArg invokeBlockWithArgs:[NSNull null], providerError, nil];
-  OCMExpect([self.mockAppCheckProvider getTokenWithCompletion:completionArg]);
+  OCMExpect([self.mockAppCheckProvider getLimitedUseTokenWithCompletion:completionArg]);
 
   // 3. Don't expect token requested from app check provider.
   OCMReject([self.mockAppCheckProvider getTokenWithCompletion:[OCMArg any]]);

--- a/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderAPIServiceTests.m
@@ -90,7 +90,8 @@ static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_
       .andReturn([FBLPromise resolvedWith:expectedResult]);
 
   // 2. Send request.
-  __auto_type tokenPromise = [self.debugAPIService appCheckTokenWithDebugToken:debugToken];
+  __auto_type tokenPromise = [self.debugAPIService appCheckTokenWithDebugToken:debugToken
+                                                                    limitedUse:NO];
 
   // 3. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
@@ -139,7 +140,8 @@ static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_
       .andReturn(rejectedPromise);
 
   // 2. Send request.
-  __auto_type tokenPromise = [self.debugAPIService appCheckTokenWithDebugToken:debugToken];
+  __auto_type tokenPromise = [self.debugAPIService appCheckTokenWithDebugToken:debugToken
+                                                                    limitedUse:NO];
 
   // 3. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
@@ -169,7 +171,8 @@ static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_
       .andReturn(rejectedPromise);
 
   // 2. Send request.
-  __auto_type tokenPromise = [self.debugAPIService appCheckTokenWithDebugToken:debugToken];
+  __auto_type tokenPromise = [self.debugAPIService appCheckTokenWithDebugToken:debugToken
+                                                                    limitedUse:NO];
 
   // 3. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));

--- a/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderAPIServiceTests.m
@@ -59,6 +59,14 @@ static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_
 }
 
 - (void)testAppCheckTokenSuccess {
+  [self testAppCheckTokenSuccessWithLimitedUse:NO];
+}
+
+- (void)testAppCheckTokenSuccessWithLimitedUse {
+  [self testAppCheckTokenSuccessWithLimitedUse:YES];
+}
+
+- (void)testAppCheckTokenSuccessWithLimitedUse:(BOOL)limitedUse {
   NSString *debugToken = [NSUUID UUID].UUIDString;
   GACAppCheckToken *expectedResult = [[GACAppCheckToken alloc] initWithToken:@"app_check_token"
                                                               expirationDate:[NSDate date]];
@@ -73,7 +81,8 @@ static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_
     return YES;
   }];
 
-  id HTTPBodyValidationArg = [self HTTPBodyValidationArgWithDebugToken:debugToken];
+  id HTTPBodyValidationArg = [self HTTPBodyValidationArgWithDebugToken:debugToken
+                                                            limitedUse:limitedUse];
   NSData *fakeResponseData = [@"fake response" dataUsingEncoding:NSUTF8StringEncoding];
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
   GULURLSessionDataResponse *APIResponse =
@@ -91,7 +100,7 @@ static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_
 
   // 2. Send request.
   __auto_type tokenPromise = [self.debugAPIService appCheckTokenWithDebugToken:debugToken
-                                                                    limitedUse:NO];
+                                                                    limitedUse:limitedUse];
 
   // 3. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
@@ -121,7 +130,7 @@ static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_
     return YES;
   }];
 
-  id HTTPBodyValidationArg = [self HTTPBodyValidationArgWithDebugToken:debugToken];
+  id HTTPBodyValidationArg = [self HTTPBodyValidationArgWithDebugToken:debugToken limitedUse:NO];
   NSData *fakeResponseData = [@"fake response" dataUsingEncoding:NSUTF8StringEncoding];
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
   GULURLSessionDataResponse *APIResponse =
@@ -163,7 +172,7 @@ static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_
   FBLPromise *rejectedPromise = [FBLPromise pendingPromise];
   [rejectedPromise reject:APIError];
 
-  id HTTPBodyValidationArg = [self HTTPBodyValidationArgWithDebugToken:debugToken];
+  id HTTPBodyValidationArg = [self HTTPBodyValidationArgWithDebugToken:debugToken limitedUse:NO];
   OCMExpect([self.mockAPIService sendRequestWithURL:[OCMArg any]
                                          HTTPMethod:@"POST"
                                                body:HTTPBodyValidationArg
@@ -186,7 +195,7 @@ static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_
 
 #pragma mark - Helpores
 
-- (id)HTTPBodyValidationArgWithDebugToken:(NSString *)debugToken {
+- (id)HTTPBodyValidationArgWithDebugToken:(NSString *)debugToken limitedUse:(BOOL)limitedUse {
   return [OCMArg checkWithBlock:^BOOL(NSData *body) {
     NSDictionary<NSString *, id> *decodedData = [NSJSONSerialization JSONObjectWithData:body
                                                                                 options:0
@@ -196,6 +205,9 @@ static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_
     NSString *decodeDebugToken = decodedData[@"debug_token"];
     XCTAssertNotNil(decodeDebugToken);
     XCTAssertEqualObjects(decodeDebugToken, debugToken);
+    NSNumber *decodedLimitedUse = decodedData[@"limited_use"];
+    XCTAssertNotNil(decodedLimitedUse);
+    XCTAssertEqualObjects(decodedLimitedUse, @(limitedUse));
     return YES;
   }];
 }

--- a/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderTests.m
+++ b/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderTests.m
@@ -165,19 +165,21 @@ typedef void (^GACAppCheckTokenValidationBlock)(GACAppCheckToken *_Nullable toke
 - (void)testGetLimitedUseTokenAPIError {
   // 1. Stub API service.
   NSString *expectedDebugToken = [self.provider currentDebugToken];
-  NSError *APIError = [NSError errorWithDomain:@"testGetLimitedUseTokenAPIError" code:-1 userInfo:nil];
+  NSError *APIError = [NSError errorWithDomain:@"testGetLimitedUseTokenAPIError"
+                                          code:-1
+                                      userInfo:nil];
   FBLPromise *rejectedPromise = [FBLPromise pendingPromise];
   [rejectedPromise reject:APIError];
   OCMExpect([self.fakeAPIService appCheckTokenWithDebugToken:expectedDebugToken limitedUse:YES])
-    .andReturn(rejectedPromise);
+      .andReturn(rejectedPromise);
   OCMReject([self.fakeAPIService appCheckTokenWithDebugToken:OCMOCK_ANY limitedUse:NO]);
-  
+
   // 2. Validate get limited-use token.
   [self validateGetLimitedUseToken:^(GACAppCheckToken *_Nullable token, NSError *_Nullable error) {
     XCTAssertEqualObjects(error, APIError);
     XCTAssertNil(token);
   }];
-  
+
   // 3. Verify fakes.
   OCMVerifyAll(self.fakeAPIService);
 }

--- a/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderTests.m
+++ b/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderTests.m
@@ -140,6 +140,48 @@ typedef void (^GACAppCheckTokenValidationBlock)(GACAppCheckToken *_Nullable toke
   OCMVerifyAll(self.fakeAPIService);
 }
 
+- (void)testGetLimitedUseTokenSuccess {
+  // 1. Stub API service.
+  NSString *expectedDebugToken = [self.provider currentDebugToken];
+  GACAppCheckToken *validToken = [[GACAppCheckToken alloc] initWithToken:@"valid_token"
+                                                          expirationDate:[NSDate date]
+                                                          receivedAtDate:[NSDate date]];
+  OCMExpect([self.fakeAPIService appCheckTokenWithDebugToken:expectedDebugToken limitedUse:YES])
+      .andReturn([FBLPromise resolvedWith:validToken]);
+  OCMReject([self.fakeAPIService appCheckTokenWithDebugToken:OCMOCK_ANY limitedUse:NO]);
+
+  // 2. Validate get limited-use token.
+  [self validateGetLimitedUseToken:^(GACAppCheckToken *_Nullable token, NSError *_Nullable error) {
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(token.token, validToken.token);
+    XCTAssertEqualObjects(token.expirationDate, validToken.expirationDate);
+    XCTAssertEqualObjects(token.receivedAtDate, validToken.receivedAtDate);
+  }];
+
+  // 3. Verify fakes.
+  OCMVerifyAll(self.fakeAPIService);
+}
+
+- (void)testGetLimitedUseTokenAPIError {
+  // 1. Stub API service.
+  NSString *expectedDebugToken = [self.provider currentDebugToken];
+  NSError *APIError = [NSError errorWithDomain:@"testGetLimitedUseTokenAPIError" code:-1 userInfo:nil];
+  FBLPromise *rejectedPromise = [FBLPromise pendingPromise];
+  [rejectedPromise reject:APIError];
+  OCMExpect([self.fakeAPIService appCheckTokenWithDebugToken:expectedDebugToken limitedUse:YES])
+    .andReturn(rejectedPromise);
+  OCMReject([self.fakeAPIService appCheckTokenWithDebugToken:OCMOCK_ANY limitedUse:NO]);
+  
+  // 2. Validate get limited-use token.
+  [self validateGetLimitedUseToken:^(GACAppCheckToken *_Nullable token, NSError *_Nullable error) {
+    XCTAssertEqualObjects(error, APIError);
+    XCTAssertNil(token);
+  }];
+  
+  // 3. Verify fakes.
+  OCMVerifyAll(self.fakeAPIService);
+}
+
 #pragma mark - Helpers
 
 - (void)validateGetToken:(GACAppCheckTokenValidationBlock)validationBlock {
@@ -149,6 +191,17 @@ typedef void (^GACAppCheckTokenValidationBlock)(GACAppCheckToken *_Nullable toke
         validationBlock(token, error);
         [expectation fulfill];
       }];
+
+  [self waitForExpectations:@[ expectation ] timeout:0.5];
+}
+
+- (void)validateGetLimitedUseToken:(GACAppCheckTokenValidationBlock)validationBlock {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"getLimitedUseToken"];
+  [self.provider getLimitedUseTokenWithCompletion:^(GACAppCheckToken *_Nullable token,
+                                                    NSError *_Nullable error) {
+    validationBlock(token, error);
+    [expectation fulfill];
+  }];
 
   [self waitForExpectations:@[ expectation ] timeout:0.5];
 }

--- a/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderTests.m
+++ b/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderTests.m
@@ -104,8 +104,9 @@ typedef void (^GACAppCheckTokenValidationBlock)(GACAppCheckToken *_Nullable toke
   GACAppCheckToken *validToken = [[GACAppCheckToken alloc] initWithToken:@"valid_token"
                                                           expirationDate:[NSDate date]
                                                           receivedAtDate:[NSDate date]];
-  OCMExpect([self.fakeAPIService appCheckTokenWithDebugToken:expectedDebugToken])
+  OCMExpect([self.fakeAPIService appCheckTokenWithDebugToken:expectedDebugToken limitedUse:NO])
       .andReturn([FBLPromise resolvedWith:validToken]);
+  OCMReject([self.fakeAPIService appCheckTokenWithDebugToken:OCMOCK_ANY limitedUse:YES]);
 
   // 2. Validate get token.
   [self validateGetToken:^(GACAppCheckToken *_Nullable token, NSError *_Nullable error) {
@@ -125,8 +126,9 @@ typedef void (^GACAppCheckTokenValidationBlock)(GACAppCheckToken *_Nullable toke
   NSError *APIError = [NSError errorWithDomain:@"testGetTokenAPIError" code:-1 userInfo:nil];
   FBLPromise *rejectedPromise = [FBLPromise pendingPromise];
   [rejectedPromise reject:APIError];
-  OCMExpect([self.fakeAPIService appCheckTokenWithDebugToken:expectedDebugToken])
+  OCMExpect([self.fakeAPIService appCheckTokenWithDebugToken:expectedDebugToken limitedUse:NO])
       .andReturn(rejectedPromise);
+  OCMReject([self.fakeAPIService appCheckTokenWithDebugToken:OCMOCK_ANY limitedUse:YES]);
 
   // 2. Validate get token.
   [self validateGetToken:^(GACAppCheckToken *_Nullable token, NSError *_Nullable error) {

--- a/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
@@ -62,6 +62,14 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
 }
 
 - (void)testAppCheckTokenSuccess {
+  [self testAppCheckTokenSuccessWithLimitedUse:NO];
+}
+
+- (void)testAppCheckTokenSuccessWithLimitedUse {
+  [self testAppCheckTokenSuccessWithLimitedUse:YES];
+}
+
+- (void)testAppCheckTokenSuccessWithLimitedUse:(BOOL)limitedUse {
   NSData *deviceTokenData = [@"device_token" dataUsingEncoding:NSUTF8StringEncoding];
   GACAppCheckToken *expectedResult = [[GACAppCheckToken alloc] initWithToken:@"app_check_token"
                                                               expirationDate:[NSDate date]];
@@ -76,7 +84,8 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
     return YES;
   }];
 
-  id HTTPBodyValidationArg = [self HTTPBodyValidationArgWithDeviceToken:deviceTokenData];
+  id HTTPBodyValidationArg = [self HTTPBodyValidationArgWithDeviceToken:deviceTokenData
+                                                             limitedUse:limitedUse];
 
   NSData *responseBody =
       [GACFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
@@ -98,7 +107,7 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
 
   // 2. Send request.
   __auto_type tokenPromise = [self.APIService appCheckTokenWithDeviceToken:deviceTokenData
-                                                                limitedUse:NO];
+                                                                limitedUse:limitedUse];
 
   // 3. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
@@ -128,7 +137,8 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
     return YES;
   }];
 
-  id HTTPBodyValidationArg = [self HTTPBodyValidationArgWithDeviceToken:deviceTokenData];
+  id HTTPBodyValidationArg = [self HTTPBodyValidationArgWithDeviceToken:deviceTokenData
+                                                             limitedUse:NO];
 
   NSData *responseBody =
       [GACFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
@@ -174,7 +184,8 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
   FBLPromise *rejectedPromise = [FBLPromise pendingPromise];
   [rejectedPromise reject:APIError];
 
-  id HTTPBodyValidationArg = [self HTTPBodyValidationArgWithDeviceToken:deviceTokenData];
+  id HTTPBodyValidationArg = [self HTTPBodyValidationArgWithDeviceToken:deviceTokenData
+                                                             limitedUse:NO];
   OCMExpect([self.mockAPIService sendRequestWithURL:[OCMArg any]
                                          HTTPMethod:@"POST"
                                                body:HTTPBodyValidationArg
@@ -227,7 +238,7 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
 
 #pragma mark - Helpers
 
-- (id)HTTPBodyValidationArgWithDeviceToken:(NSData *)deviceToken {
+- (id)HTTPBodyValidationArgWithDeviceToken:(NSData *)deviceToken limitedUse:(BOOL)limitedUse {
   return [OCMArg checkWithBlock:^BOOL(NSData *body) {
     NSDictionary<NSString *, id> *decodedData = [NSJSONSerialization JSONObjectWithData:body
                                                                                 options:0
@@ -236,6 +247,10 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
 
     NSString *base64EncodedDeviceToken = decodedData[@"device_token"];
     XCTAssertNotNil(base64EncodedDeviceToken);
+
+    NSNumber *decodedLimitedUse = decodedData[@"limited_use"];
+    XCTAssertNotNil(decodedLimitedUse);
+    XCTAssertEqualObjects(decodedLimitedUse, @(limitedUse));
 
     NSData *decodedToken = [[NSData alloc] initWithBase64EncodedString:base64EncodedDeviceToken
                                                                options:0];

--- a/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
@@ -97,7 +97,8 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
       .andReturn([FBLPromise resolvedWith:expectedResult]);
 
   // 2. Send request.
-  __auto_type tokenPromise = [self.APIService appCheckTokenWithDeviceToken:deviceTokenData];
+  __auto_type tokenPromise = [self.APIService appCheckTokenWithDeviceToken:deviceTokenData
+                                                                limitedUse:NO];
 
   // 3. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
@@ -150,7 +151,8 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
       .andReturn(rejectedPromise);
 
   // 2. Send request.
-  __auto_type tokenPromise = [self.APIService appCheckTokenWithDeviceToken:deviceTokenData];
+  __auto_type tokenPromise = [self.APIService appCheckTokenWithDeviceToken:deviceTokenData
+                                                                limitedUse:NO];
 
   // 3. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
@@ -180,7 +182,8 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
       .andReturn(rejectedPromise);
 
   // 2. Send request.
-  __auto_type tokenPromise = [self.APIService appCheckTokenWithDeviceToken:deviceTokenData];
+  __auto_type tokenPromise = [self.APIService appCheckTokenWithDeviceToken:deviceTokenData
+                                                                limitedUse:NO];
 
   // 3. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
@@ -202,7 +205,8 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
                                   additionalHeaders:[OCMArg any]]);
 
   // 2. Send request.
-  __auto_type tokenPromise = [self.APIService appCheckTokenWithDeviceToken:deviceTokenData];
+  __auto_type tokenPromise = [self.APIService appCheckTokenWithDeviceToken:deviceTokenData
+                                                                limitedUse:NO];
 
   // 3. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));

--- a/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckProviderTests.m
+++ b/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckProviderTests.m
@@ -79,8 +79,9 @@ GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
   GACAppCheckToken *validToken = [[GACAppCheckToken alloc] initWithToken:@"valid_token"
                                                           expirationDate:[NSDate distantFuture]
                                                           receivedAtDate:[NSDate date]];
-  OCMExpect([self.fakeAPIService appCheckTokenWithDeviceToken:deviceToken])
+  OCMExpect([self.fakeAPIService appCheckTokenWithDeviceToken:deviceToken limitedUse:NO])
       .andReturn([FBLPromise resolvedWith:validToken]);
+  OCMReject([self.fakeAPIService appCheckTokenWithDeviceToken:OCMOCK_ANY limitedUse:YES]);
 
   // 3. Expect backoff wrapper to be used.
   self.fakeBackoffWrapper.backoffExpectation = [self expectationWithDescription:@"Backoff"];
@@ -134,7 +135,8 @@ GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
   OCMExpect([self.fakeTokenGenerator generateTokenWithCompletionHandler:generateTokenArg]);
 
   // 2. Don't expect FAA token to be requested.
-  OCMReject([self.fakeAPIService appCheckTokenWithDeviceToken:[OCMArg any]]);
+  OCMReject([self.fakeAPIService appCheckTokenWithDeviceToken:OCMOCK_ANY limitedUse:NO])
+      .ignoringNonObjectArgs();
 
   // 3. Call getToken and validate the result.
   XCTestExpectation *completionExpectation =
@@ -184,8 +186,9 @@ GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
   // 2. Expect FAA token to be requested.
   FBLPromise *rejectedPromise = [FBLPromise pendingPromise];
   [rejectedPromise reject:APIServiceError];
-  OCMExpect([self.fakeAPIService appCheckTokenWithDeviceToken:deviceToken])
+  OCMExpect([self.fakeAPIService appCheckTokenWithDeviceToken:deviceToken limitedUse:NO])
       .andReturn(rejectedPromise);
+  OCMReject([self.fakeAPIService appCheckTokenWithDeviceToken:OCMOCK_ANY limitedUse:YES]);
 
   // 3. Call getToken and validate the result.
   XCTestExpectation *completionExpectation =
@@ -219,7 +222,8 @@ GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
   self.fakeBackoffWrapper.backoffExpectation = [self expectationWithDescription:@"Backoff"];
 
   // 2. Don't expect any operations.
-  OCMReject([self.fakeAPIService appCheckTokenWithDeviceToken:[OCMArg any]]);
+  OCMReject([self.fakeAPIService appCheckTokenWithDeviceToken:OCMOCK_ANY limitedUse:NO])
+      .ignoringNonObjectArgs();
   OCMReject([self.fakeTokenGenerator generateTokenWithCompletionHandler:OCMOCK_ANY]);
 
   // 3. Call getToken and validate the result.

--- a/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -197,6 +197,13 @@ class DummyAppCheckProvider: NSObject, AppCheckCoreProvider {
   func getToken(completion handler: @escaping (AppCheckCoreToken?, Error?) -> Void) {
     handler(AppCheckCoreToken(token: "token", expirationDate: .distantFuture), nil)
   }
+
+  func getLimitedUseToken(completion handler: @escaping (AppCheckCoreToken?, Error?) -> Void) {
+    handler(
+      AppCheckCoreToken(token: "token", expirationDate: .init(timeIntervalSinceNow: 3600)),
+      nil
+    )
+  }
 }
 
 class DummyAppCheckSettings: NSObject, AppCheckCoreSettingsProtocol {


### PR DESCRIPTION
Added support for generating App Check tokens with a TTL of 5 minutes when requesting limited-use tokens. This extends upon https://github.com/firebase/firebase-ios-sdk/pull/11086, which added the ability to request limited-use tokens that aren't cached.

This is implemented by adding a `getLimitedUseTokenWithCompletion:` method to the `GACAppCheckProvider` protocol. When requesting a limited-use token through the public API [`limitedUseTokenWithCompletion:`](https://github.com/google/app-check/blob/c3bf9c299f3a4761f973164777409a6992c5ab1c/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h#L42-L47), the new `GACAppCheckProvider` method `getLimitedUseTokenWithCompletion:` will be called instead of the existing `getTokenWithCompletion:` method.

TODOs:
- [x] Add `getLimitedUseTokenWithCompletion:` to `GACAppCheckProvider`
- [x] Call `getLimitedUseTokenWithCompletion:` from `GACAppCheck` in `limitedUseTokenWithCompletion:`
- [x] Implement `getLimitedUseTokenWithCompletion:` in providers:
  - [x] `GACAppAttestProvider`
  - [x] `GACAppCheckDebugProvider`
  - [x] `GACDeviceCheckProvider`
- [x] Update existing tests to ensure existing behaviour is unchanged
- [x] Add new tests to check limited-use methods set `limitedUse` as `YES`
