### PR TITLE
Make `GACAppAttestProvider`'s constructor `nonnull`

### DIFF
--- a/AppCheckCore/Sources/AppAttestProvider/DCAppAttestService+GACAppAttestService.h
+++ b/AppCheckCore/Sources/AppAttestProvider/DCAppAttestService+GACAppAttestService.h
@@ -18,9 +18,6 @@
 
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckAvailability.h"
 
-// Currently DCAppAttestService is available on iOS only.
-#if GAC_APP_ATTEST_SUPPORTED_TARGETS
-
 #import <DeviceCheck/DeviceCheck.h>
 
 #import "AppCheckCore/Sources/AppAttestProvider/GACAppAttestService.h"
@@ -33,5 +30,3 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
 @end
 
 NS_ASSUME_NONNULL_END
-
-#endif  // GAC_APP_ATTEST_SUPPORTED_TARGETS

--- a/AppCheckCore/Sources/AppAttestProvider/DCAppAttestService+GACAppAttestService.m
+++ b/AppCheckCore/Sources/AppAttestProvider/DCAppAttestService+GACAppAttestService.m
@@ -16,11 +16,6 @@
 
 #import "AppCheckCore/Sources/AppAttestProvider/DCAppAttestService+GACAppAttestService.h"
 
-// Currently DCAppAttestService is available on iOS only.
-#if GAC_APP_ATTEST_SUPPORTED_TARGETS
-
 @implementation DCAppAttestService (GACAppAttestService)
 
 @end
-
-#endif  // GAC_APP_ATTEST_SUPPORTED_TARGETS

--- a/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -158,7 +158,6 @@ NS_ASSUME_NONNULL_BEGIN
                                   limitedUse:(BOOL)limitedUse
                                 requestHooks:
                                     (nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
-#if GAC_APP_ATTEST_SUPPORTED_TARGETS
   NSURLSession *URLSession = [NSURLSession
       sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
 
@@ -190,9 +189,6 @@ NS_ASSUME_NONNULL_BEGIN
                            keyIDStorage:keyIDStorage
                         artifactStorage:artifactStorage
                          backoffWrapper:backoffWrapper];
-#else   // GAC_APP_ATTEST_SUPPORTED_TARGETS
-  return nil;
-#endif  // GAC_APP_ATTEST_SUPPORTED_TARGETS
 }
 
 #pragma mark - GACAppCheckProvider

--- a/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -134,13 +134,12 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
-- (nullable instancetype)initWithServiceName:(NSString *)serviceName
-                                resourceName:(NSString *)resourceName
-                                     baseURL:(nullable NSString *)baseURL
-                                      APIKey:(nullable NSString *)APIKey
-                         keychainAccessGroup:(nullable NSString *)accessGroup
-                                requestHooks:
-                                    (nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
+- (instancetype)initWithServiceName:(NSString *)serviceName
+                       resourceName:(NSString *)resourceName
+                            baseURL:(nullable NSString *)baseURL
+                             APIKey:(nullable NSString *)APIKey
+                keychainAccessGroup:(nullable NSString *)accessGroup
+                       requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
   return [self initWithServiceName:serviceName
                       resourceName:resourceName
                            baseURL:baseURL
@@ -150,14 +149,13 @@ NS_ASSUME_NONNULL_BEGIN
                       requestHooks:requestHooks];
 }
 
-- (nullable instancetype)initWithServiceName:(NSString *)serviceName
-                                resourceName:(NSString *)resourceName
-                                     baseURL:(nullable NSString *)baseURL
-                                      APIKey:(nullable NSString *)APIKey
-                         keychainAccessGroup:(nullable NSString *)accessGroup
-                                  limitedUse:(BOOL)limitedUse
-                                requestHooks:
-                                    (nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
+- (instancetype)initWithServiceName:(NSString *)serviceName
+                       resourceName:(NSString *)resourceName
+                            baseURL:(nullable NSString *)baseURL
+                             APIKey:(nullable NSString *)APIKey
+                keychainAccessGroup:(nullable NSString *)accessGroup
+                         limitedUse:(BOOL)limitedUse
+                       requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
   NSURLSession *URLSession = [NSURLSession
       sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
 

--- a/AppCheckCore/Sources/DeviceCheckProvider/DCDevice+GACDeviceCheckTokenGenerator.h
+++ b/AppCheckCore/Sources/DeviceCheckProvider/DCDevice+GACDeviceCheckTokenGenerator.h
@@ -16,18 +16,15 @@
 
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckAvailability.h"
 
-#if GAC_DEVICE_CHECK_SUPPORTED_TARGETS
-
 #import <DeviceCheck/DeviceCheck.h>
 
 #import "AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckTokenGenerator.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
 @interface DCDevice (GACDeviceCheckTokenGenerator) <GACDeviceCheckTokenGenerator>
 
 @end
 
 NS_ASSUME_NONNULL_END
-
-#endif  // GAC_DEVICE_CHECK_SUPPORTED_TARGETS

--- a/AppCheckCore/Sources/DeviceCheckProvider/DCDevice+GACDeviceCheckTokenGenerator.m
+++ b/AppCheckCore/Sources/DeviceCheckProvider/DCDevice+GACDeviceCheckTokenGenerator.m
@@ -16,10 +16,6 @@
 
 #import "AppCheckCore/Sources/DeviceCheckProvider/DCDevice+GACDeviceCheckTokenGenerator.h"
 
-#if GAC_DEVICE_CHECK_SUPPORTED_TARGETS
-
 @implementation DCDevice (GACDeviceCheckTokenGenerator)
 
 @end
-
-#endif  // GAC_DEVICE_CHECK_SUPPORTED_TARGETS

--- a/AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
+++ b/AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
@@ -16,8 +16,6 @@
 
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckAvailability.h"
 
-#if GAC_DEVICE_CHECK_SUPPORTED_TARGETS
-
 #import <Foundation/Foundation.h>
 
 #if __has_include(<FBLPromises/FBLPromises.h>)
@@ -129,5 +127,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-
-#endif  // GAC_DEVICE_CHECK_SUPPORTED_TARGETS

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppAttestProvider.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppAttestProvider.h
@@ -42,14 +42,13 @@ NS_SWIFT_NAME(AppCheckCoreAppAttestProvider)
 /// @param APIKey The Google Cloud Platform API key, if needed, or nil.
 /// @param accessGroup The Keychain Access Group.
 /// @param requestHooks Hooks that will be invoked on requests through this service.
-/// @return An instance of `AppAttestProvider` if App Attest is supported or `nil`.
-- (nullable instancetype)initWithServiceName:(NSString *)serviceName
-                                resourceName:(NSString *)resourceName
-                                     baseURL:(nullable NSString *)baseURL
-                                      APIKey:(nullable NSString *)APIKey
-                         keychainAccessGroup:(nullable NSString *)accessGroup
-                                requestHooks:
-                                    (nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
+/// @return An instance of `AppAttestProvider`.
+- (instancetype)initWithServiceName:(NSString *)serviceName
+                       resourceName:(NSString *)resourceName
+                            baseURL:(nullable NSString *)baseURL
+                             APIKey:(nullable NSString *)APIKey
+                keychainAccessGroup:(nullable NSString *)accessGroup
+                       requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
 
 /// Initializer with support for short-lived tokens.
 ///
@@ -66,15 +65,14 @@ NS_SWIFT_NAME(AppCheckCoreAppAttestProvider)
 /// @param accessGroup The Keychain Access Group.
 /// @param limitedUse If YES, forces a short-lived token with a 5 minute TTL.
 /// @param requestHooks Hooks that will be invoked on requests through this service.
-/// @return An instance of `AppAttestProvider` if App Attest is supported or `nil`.
-- (nullable instancetype)initWithServiceName:(NSString *)serviceName
-                                resourceName:(NSString *)resourceName
-                                     baseURL:(nullable NSString *)baseURL
-                                      APIKey:(nullable NSString *)APIKey
-                         keychainAccessGroup:(nullable NSString *)accessGroup
-                                  limitedUse:(BOOL)limitedUse
-                                requestHooks:
-                                    (nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
+/// @return An instance of `AppAttestProvider`.
+- (instancetype)initWithServiceName:(NSString *)serviceName
+                       resourceName:(NSString *)resourceName
+                            baseURL:(nullable NSString *)baseURL
+                             APIKey:(nullable NSString *)APIKey
+                keychainAccessGroup:(nullable NSString *)accessGroup
+                         limitedUse:(BOOL)limitedUse
+                       requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
 
 @end
 

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckAvailability.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckAvailability.h
@@ -27,10 +27,6 @@
 
 #pragma mark - App Attest
 
-// Targets where `DCAppAttestService` is available to be used in preprocessor conditions.
-#define GAC_APP_ATTEST_SUPPORTED_TARGETS \
-  TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_TV || TARGET_OS_WATCH
-
 // `AppAttestProvider` availability annotations
 #define GAC_APP_ATTEST_PROVIDER_AVAILABILITY \
   API_AVAILABLE(ios(14.0), macos(11.3), macCatalyst(14.5), tvos(15.0), watchos(9.0))

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckAvailability.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckAvailability.h
@@ -21,10 +21,6 @@
 
 #pragma mark - DeviceCheck
 
-// Targets where DeviceCheck framework is available to be used in preprocessor conditions.
-#define GAC_DEVICE_CHECK_SUPPORTED_TARGETS \
-  TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_TV || TARGET_OS_WATCH
-
 // `DeviceCheckProvider` availability.
 #define GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY \
   API_AVAILABLE(ios(11.0), macos(10.15), macCatalyst(13.0), tvos(11.0), watchos(9.0))

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACDeviceCheckProvider.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACDeviceCheckProvider.h
@@ -19,8 +19,6 @@
 #import "GACAppCheckAvailability.h"
 #import "GACAppCheckProvider.h"
 
-#if GAC_DEVICE_CHECK_SUPPORTED_TARGETS
-
 @protocol GACDeviceCheckAPIServiceProtocol;
 @protocol GACDeviceCheckTokenGenerator;
 
@@ -52,5 +50,3 @@ NS_SWIFT_NAME(AppCheckCoreDeviceCheckProvider)
 @end
 
 NS_ASSUME_NONNULL_END
-
-#endif  // GAC_DEVICE_CHECK_SUPPORTED_TARGETS

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
@@ -35,8 +35,6 @@
 
 #import "AppCheckCore/Tests/Utils/AppCheckBackoffWrapperFake/GACAppCheckBackoffWrapperFake.h"
 
-#if GAC_APP_ATTEST_SUPPORTED_TARGETS
-
 GAC_APP_ATTEST_PROVIDER_AVAILABILITY
 @interface GACAppAttestProvider (Tests)
 - (instancetype)initWithAppAttestService:(id<GACAppAttestService>)appAttestService
@@ -1072,5 +1070,3 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
 }
 
 @end
-
-#endif  // GAC_APP_ATTEST_SUPPORTED_TARGETS

--- a/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckProviderTests.m
+++ b/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckProviderTests.m
@@ -26,8 +26,6 @@
 
 #import "AppCheckCore/Tests/Utils/AppCheckBackoffWrapperFake/GACAppCheckBackoffWrapperFake.h"
 
-#if GAC_DEVICE_CHECK_SUPPORTED_TARGETS
-
 GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
 @interface GACDeviceCheckProvider (Tests)
 
@@ -244,5 +242,3 @@ GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
 }
 
 @end
-
-#endif  // GAC_DEVICE_CHECK_SUPPORTED_TARGETS

--- a/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -31,15 +31,18 @@ final class AppCheckAPITests {
 
     if #available(iOS 14.0, macOS 11.3, macCatalyst 14.5, tvOS 15.0, watchOS 9.0, *) {
       // TODO(andrewheard): Add `requestHooks` in API tests.
-      if let provider = AppCheckCoreAppAttestProvider(
+      let provider = AppCheckCoreAppAttestProvider(
         serviceName: serviceName,
         resourceName: resourceName,
         baseURL: nil,
         apiKey: apiKey,
         keychainAccessGroup: nil,
         requestHooks: nil
-      ) {
-        provider.getToken { token, error in
+      )
+      provider.getToken { token, error in
+        if let _ /* error */ = error {
+          // ...
+        } else if let _ /* token */ = token {
           // ...
         }
       }


### PR DESCRIPTION
`GACAppAttestProvider`'s constructor would previously return `nil` if running on an unsupported platform. App Attest and DeviceCheck are now supported on all of the platforms that we support, including the upcoming visionOS, so `GAC_DEVICE_CHECK_SUPPORTED_TARGETS` and `GAC_APP_ATTEST_SUPPORTED_TARGETS` (both `TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_TV || TARGET_OS_WATCH`) are always true so they have been removed. The `GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY` and `GAC_APP_ATTEST_PROVIDER_AVAILABILITY` are still necessary since the APIs aren't available on all versions of the platforms we support.

This makes the `GACAppAttestProvider` more consistent with `GACDeviceCheckProvider` which never returns `nil`. An alternative approach would be to make `GACDeviceCheckProvider`'s constructor `nullable` and return `nil` when not supported at runtime but I think it would be cleaner to port https://github.com/firebase/firebase-ios-sdk/pull/11663 instead (since it provides an error message to aid debugging).