### PR TITLE
Add DeviceCheck `isSupported` check

### DIFF
--- a/AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
+++ b/AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
@@ -28,6 +28,7 @@
 
 #import "AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.h"
 #import "AppCheckCore/Sources/Core/Backoff/GACAppCheckBackoffWrapper.h"
+#import "AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 #import "AppCheckCore/Sources/Core/GACAppCheckLogger+Internal.h"
 #import "AppCheckCore/Sources/DeviceCheckProvider/API/GACDeviceCheckAPIService.h"
 #import "AppCheckCore/Sources/DeviceCheckProvider/DCDevice+GACDeviceCheckTokenGenerator.h"
@@ -118,10 +119,26 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - DeviceCheck
 
 - (FBLPromise<NSData *> *)deviceToken {
-  return [FBLPromise
-      wrapObjectOrErrorCompletion:^(FBLPromiseObjectOrErrorCompletion _Nonnull handler) {
-        [self.deviceTokenGenerator generateTokenWithCompletionHandler:handler];
-      }];
+  return [self isDeviceCheckSupported].then(^FBLPromise<NSData *> *(NSNull *ignored) {
+    return [FBLPromise
+        wrapObjectOrErrorCompletion:^(FBLPromiseObjectOrErrorCompletion _Nonnull handler) {
+          [self.deviceTokenGenerator generateTokenWithCompletionHandler:handler];
+        }];
+  });
+}
+
+#pragma mark - Helpers
+
+/// Returns a resolved promise if DeviceCheck is supported and a rejected promise if it is not.
+- (FBLPromise<NSNull *> *)isDeviceCheckSupported {
+  if (self.deviceTokenGenerator.isSupported) {
+    return [FBLPromise resolvedWith:[NSNull null]];
+  } else {
+    NSError *error = [GACAppCheckErrorUtil unsupportedAttestationProvider:@"DeviceCheckProvider"];
+    FBLPromise *rejectedPromise = [FBLPromise pendingPromise];
+    [rejectedPromise reject:error];
+    return rejectedPromise;
+  }
 }
 
 @end

--- a/AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckTokenGenerator.h
+++ b/AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckTokenGenerator.h
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol GACDeviceCheckTokenGenerator <NSObject>
 
+@property(getter=isSupported, readonly) BOOL supported;
+
 - (void)generateTokenWithCompletionHandler:(void (^)(NSData* _Nullable token,
                                                      NSError* _Nullable error))completion;
 

--- a/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckProviderTests.m
+++ b/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckProviderTests.m
@@ -19,6 +19,7 @@
 #import <OCMock/OCMock.h>
 #import "FBLPromise+Testing.h"
 
+#import "AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 #import "AppCheckCore/Sources/DeviceCheckProvider/API/GACDeviceCheckAPIService.h"
 #import "AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckTokenGenerator.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckToken.h"
@@ -70,22 +71,25 @@ GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
 }
 
 - (void)testGetTokenSuccess {
-  // 1. Expect device token to be generated.
+  // 1. Expect GACDeviceCheckTokenGenerator.isSupported.
+  OCMExpect([self.fakeTokenGenerator isSupported]).andReturn(YES);
+
+  // 2. Expect device token to be generated.
   NSData *deviceToken = [NSData data];
   id generateTokenArg = [OCMArg invokeBlockWithArgs:deviceToken, [NSNull null], nil];
   OCMExpect([self.fakeTokenGenerator generateTokenWithCompletionHandler:generateTokenArg]);
 
-  // 2. Expect FAA token to be requested.
+  // 3. Expect FAA token to be requested.
   GACAppCheckToken *validToken = [[GACAppCheckToken alloc] initWithToken:@"valid_token"
                                                           expirationDate:[NSDate distantFuture]
                                                           receivedAtDate:[NSDate date]];
   OCMExpect([self.fakeAPIService appCheckTokenWithDeviceToken:deviceToken])
       .andReturn([FBLPromise resolvedWith:validToken]);
 
-  // 3. Expect backoff wrapper to be used.
+  // 4. Expect backoff wrapper to be used.
   self.fakeBackoffWrapper.backoffExpectation = [self expectationWithDescription:@"Backoff"];
 
-  // 4. Call getToken and validate the result.
+  // 5. Call getToken and validate the result.
   XCTestExpectation *completionExpectation =
       [self expectationWithDescription:@"completionExpectation"];
   [self.provider
@@ -101,7 +105,7 @@ GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
                     timeout:0.5
                enforceOrder:YES];
 
-  // 5. Verify.
+  // 6. Verify.
   XCTAssertNil(self.fakeBackoffWrapper.operationError);
   GACAppCheckToken *wrapperResult =
       [self.fakeBackoffWrapper.operationResult isKindOfClass:[GACAppCheckToken class]]
@@ -111,6 +115,52 @@ GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
 
   OCMVerifyAll(self.fakeAPIService);
   OCMVerifyAll(self.fakeTokenGenerator);
+}
+
+- (void)testGetTokenWhenDeviceCheckIsNotSupported {
+  NSError *expectedError =
+      [GACAppCheckErrorUtil unsupportedAttestationProvider:@"DeviceCheckProvider"];
+
+  // 0.1. Expect backoff wrapper to be used.
+  self.fakeBackoffWrapper.backoffExpectation = [self expectationWithDescription:@"Backoff"];
+
+  // 0.2. Expect default error handler to be used.
+  XCTestExpectation *errorHandlerExpectation = [self expectationWithDescription:@"Error handler"];
+  self.fakeBackoffWrapper.defaultErrorHandler = ^GACAppCheckBackoffType(NSError *_Nonnull error) {
+    XCTAssertEqualObjects(error, expectedError);
+    [errorHandlerExpectation fulfill];
+    return GACAppCheckBackoffType1Day;
+  };
+
+  // 1. Expect GACDeviceCheckTokenGenerator.isSupported.
+  OCMExpect([self.fakeTokenGenerator isSupported]).andReturn(NO);
+
+  // 2. Don't expect DeviceCheck token to be generated or FAA token to be requested.
+  OCMReject([self.fakeTokenGenerator generateTokenWithCompletionHandler:OCMOCK_ANY]);
+  OCMReject([self.fakeAPIService appCheckTokenWithDeviceToken:OCMOCK_ANY]);
+
+  // 3. Call getToken and validate the result.
+  XCTestExpectation *completionExpectation =
+      [self expectationWithDescription:@"completionExpectation"];
+  [self.provider
+      getTokenWithCompletion:^(GACAppCheckToken *_Nullable token, NSError *_Nullable error) {
+        [completionExpectation fulfill];
+        XCTAssertNil(token);
+        XCTAssertEqualObjects(error, expectedError);
+      }];
+
+  [self waitForExpectations:@[
+    self.fakeBackoffWrapper.backoffExpectation, errorHandlerExpectation, completionExpectation
+  ]
+                    timeout:0.5
+               enforceOrder:YES];
+
+  // 4. Verify.
+  OCMVerifyAll(self.fakeAPIService);
+  OCMVerifyAll(self.fakeTokenGenerator);
+
+  XCTAssertEqualObjects(self.fakeBackoffWrapper.operationError, expectedError);
+  XCTAssertNil(self.fakeBackoffWrapper.operationResult);
 }
 
 - (void)testGetTokenWhenDeviceTokenFails {
@@ -129,14 +179,17 @@ GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
     return GACAppCheckBackoffType1Day;
   };
 
-  // 1. Expect device token to be generated.
+  // 1. Expect GACDeviceCheckTokenGenerator.isSupported.
+  OCMExpect([self.fakeTokenGenerator isSupported]).andReturn(YES);
+
+  // 2. Expect device token to be generated.
   id generateTokenArg = [OCMArg invokeBlockWithArgs:[NSNull null], deviceTokenError, nil];
   OCMExpect([self.fakeTokenGenerator generateTokenWithCompletionHandler:generateTokenArg]);
 
-  // 2. Don't expect FAA token to be requested.
+  // 3. Don't expect FAA token to be requested.
   OCMReject([self.fakeAPIService appCheckTokenWithDeviceToken:[OCMArg any]]);
 
-  // 3. Call getToken and validate the result.
+  // 4. Call getToken and validate the result.
   XCTestExpectation *completionExpectation =
       [self expectationWithDescription:@"completionExpectation"];
   [self.provider
@@ -152,7 +205,7 @@ GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
                     timeout:0.5
                enforceOrder:YES];
 
-  // 4. Verify.
+  // 5. Verify.
   OCMVerifyAll(self.fakeAPIService);
   OCMVerifyAll(self.fakeTokenGenerator);
 
@@ -176,18 +229,21 @@ GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
     return GACAppCheckBackoffType1Day;
   };
 
-  // 1. Expect device token to be generated.
+  // 1. Expect GACDeviceCheckTokenGenerator.isSupported.
+  OCMExpect([self.fakeTokenGenerator isSupported]).andReturn(YES);
+
+  // 2. Expect device token to be generated.
   NSData *deviceToken = [NSData data];
   id generateTokenArg = [OCMArg invokeBlockWithArgs:deviceToken, [NSNull null], nil];
   OCMExpect([self.fakeTokenGenerator generateTokenWithCompletionHandler:generateTokenArg]);
 
-  // 2. Expect FAA token to be requested.
+  // 3. Expect FAA token to be requested.
   FBLPromise *rejectedPromise = [FBLPromise pendingPromise];
   [rejectedPromise reject:APIServiceError];
   OCMExpect([self.fakeAPIService appCheckTokenWithDeviceToken:deviceToken])
       .andReturn(rejectedPromise);
 
-  // 3. Call getToken and validate the result.
+  // 4. Call getToken and validate the result.
   XCTestExpectation *completionExpectation =
       [self expectationWithDescription:@"completionExpectation"];
   [self.provider
@@ -203,7 +259,7 @@ GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
                     timeout:0.5
                enforceOrder:YES];
 
-  // 4. Verify.
+  // 5. Verify.
   OCMVerifyAll(self.fakeAPIService);
   OCMVerifyAll(self.fakeTokenGenerator);
 


### PR DESCRIPTION
Added a DeviceCheck `isSupported` check and return a `GACAppCheckErrorCodeUnsupported` error when not supported (e.g., when running on the simulator or older Macs).

This is a port of https://github.com/firebase/firebase-ios-sdk/pull/11663 to `AppCheckCore`.