### PR TITLE
Remove `get` prefix from `getTokenForcingRefresh` and `getLimitedUseToken`

### DIFF
--- a/AppCheckCore/Sources/Core/GACAppCheck.m
+++ b/AppCheckCore/Sources/Core/GACAppCheck.m
@@ -111,9 +111,7 @@ typedef void (^GACAppCheckTokenHandler)(id<GACAppCheckTokenProtocol> _Nullable t
                      tokenDelegate:tokenDelegate];
 }
 
-#pragma mark - GACAppCheckInterop
-
-- (void)getTokenForcingRefresh:(BOOL)forcingRefresh completion:(GACAppCheckTokenHandler)handler {
+- (void)tokenForcingRefresh:(BOOL)forcingRefresh completion:(GACAppCheckTokenHandler)handler {
   [self retrieveOrRefreshTokenForcingRefresh:forcingRefresh]
       .then(^id _Nullable(id<GACAppCheckTokenProtocol> token) {
         handler(token, nil);
@@ -124,7 +122,7 @@ typedef void (^GACAppCheckTokenHandler)(id<GACAppCheckTokenProtocol> _Nullable t
       });
 }
 
-- (void)getLimitedUseTokenWithCompletion:(GACAppCheckTokenHandler)handler {
+- (void)limitedUseTokenWithCompletion:(GACAppCheckTokenHandler)handler {
   [self limitedUseToken]
       .then(^id _Nullable(id<GACAppCheckTokenProtocol> token) {
         handler(token, nil);

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h
@@ -34,17 +34,17 @@ NS_SWIFT_NAME(AppCheckCoreProtocol) @protocol GACAppCheckProtocol
 /// error, indicating a revoked token.
 /// @param handler The completion handler. Includes the app check token if the request succeeds,
 /// or an error if the request fails.
-- (void)getTokenForcingRefresh:(BOOL)forcingRefresh
-                    completion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable token,
-                                         NSError *_Nullable error))handler
+- (void)tokenForcingRefresh:(BOOL)forcingRefresh
+                 completion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable token,
+                                      NSError *_Nullable error))handler
     NS_SWIFT_NAME(token(forcingRefresh:completion:));
 
 /// Retrieve a new limited-use App Check token
 ///
 /// This method does not affect the token generation behavior of the
 /// ``tokenForcingRefresh()`` method.
-- (void)getLimitedUseTokenWithCompletion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable token,
-                                                   NSError *_Nullable error))handler;
+- (void)limitedUseTokenWithCompletion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable token,
+                                                NSError *_Nullable error))handler;
 
 @end
 

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckTests.m
@@ -181,13 +181,13 @@ static NSString *const kAppGroupID = @"app_group_id";
 
   // 2. Request token and verify result.
   [self.appCheck
-      getTokenForcingRefresh:NO
-                  completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
-                    [expectation fulfill];
-                    XCTAssertNotNil(token);
-                    XCTAssertEqualObjects(token.token, expectedToken.token);
-                    XCTAssertNil(error);
-                  }];
+      tokenForcingRefresh:NO
+               completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
+                 [expectation fulfill];
+                 XCTAssertNotNil(token);
+                 XCTAssertEqualObjects(token.token, expectedToken.token);
+                 XCTAssertNil(error);
+               }];
 
   // 3. Wait for expectations and validate mocks.
   [self waitForExpectations:@[ expectation ] timeout:0.5];
@@ -207,13 +207,13 @@ static NSString *const kAppGroupID = @"app_group_id";
 
   // 2. Request token and verify result.
   [self.appCheck
-      getTokenForcingRefresh:YES
-                  completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
-                    [expectation fulfill];
-                    XCTAssertNotNil(token);
-                    XCTAssertEqualObjects(token.token, expectedToken.token);
-                    XCTAssertNil(error);
-                  }];
+      tokenForcingRefresh:YES
+               completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
+                 [expectation fulfill];
+                 XCTAssertNotNil(token);
+                 XCTAssertEqualObjects(token.token, expectedToken.token);
+                 XCTAssertNil(error);
+               }];
 
   // 3. Wait for expectations and validate mocks.
   [self waitForExpectations:@[ expectation ] timeout:0.5];
@@ -229,13 +229,13 @@ static NSString *const kAppGroupID = @"app_group_id";
 
   // 2. Request token and verify result.
   [self.appCheck
-      getTokenForcingRefresh:NO
-                  completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
-                    [expectation fulfill];
-                    XCTAssertNotNil(token);
-                    XCTAssertEqualObjects(token.token, expectedToken.token);
-                    XCTAssertNil(error);
-                  }];
+      tokenForcingRefresh:NO
+               completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
+                 [expectation fulfill];
+                 XCTAssertNotNil(token);
+                 XCTAssertEqualObjects(token.token, expectedToken.token);
+                 XCTAssertNil(error);
+               }];
 
   // 3. Wait for expectations and validate mocks.
   [self waitForExpectations:@[ expectation ] timeout:0.5];
@@ -252,14 +252,14 @@ static NSString *const kAppGroupID = @"app_group_id";
 
   // 2. Request token and verify result.
   [self.appCheck
-      getTokenForcingRefresh:NO
-                  completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
-                    [expectation fulfill];
-                    XCTAssertNil(token);
-                    XCTAssertEqualObjects(error, providerError);
-                    // Interop API does not wrap errors in public domain.
-                    XCTAssertNotEqualObjects(error.domain, GACAppCheckErrorDomain);
-                  }];
+      tokenForcingRefresh:NO
+               completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
+                 [expectation fulfill];
+                 XCTAssertNil(token);
+                 XCTAssertEqualObjects(error, providerError);
+                 // Interop API does not wrap errors in public domain.
+                 XCTAssertNotEqualObjects(error.domain, GACAppCheckErrorDomain);
+               }];
 
   // 3. Wait for expectations and validate mocks.
   [self waitForExpectations:@[ expectation ] timeout:0.5];
@@ -355,8 +355,8 @@ static NSString *const kAppGroupID = @"app_group_id";
   // 5. Expect token request to be completed.
   XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
 
-  [self.appCheck getLimitedUseTokenWithCompletion:^(id<GACAppCheckTokenProtocol> _Nullable token,
-                                                    NSError *_Nullable error) {
+  [self.appCheck limitedUseTokenWithCompletion:^(id<GACAppCheckTokenProtocol> _Nullable token,
+                                                 NSError *_Nullable error) {
     [getTokenExpectation fulfill];
     XCTAssertNotNil(token);
     XCTAssertEqualObjects(token.token, expectedToken.token);
@@ -384,8 +384,8 @@ static NSString *const kAppGroupID = @"app_group_id";
   // 5. Expect token request to be completed.
   XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
 
-  [self.appCheck getLimitedUseTokenWithCompletion:^(id<GACAppCheckTokenProtocol> _Nullable token,
-                                                    NSError *_Nullable error) {
+  [self.appCheck limitedUseTokenWithCompletion:^(id<GACAppCheckTokenProtocol> _Nullable token,
+                                                 NSError *_Nullable error) {
     [getTokenExpectation fulfill];
     XCTAssertNotNil(error);
     XCTAssertNil(token.token);
@@ -423,13 +423,13 @@ static NSString *const kAppGroupID = @"app_group_id";
 
     // 3.2. Request token and verify result.
     [self.appCheck
-        getTokenForcingRefresh:NO
-                    completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
-                      [getTokenExpectation fulfill];
-                      XCTAssertNotNil(token);
-                      XCTAssertEqualObjects(token.token, expectedToken.token);
-                      XCTAssertNil(error);
-                    }];
+        tokenForcingRefresh:NO
+                 completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
+                   [getTokenExpectation fulfill];
+                   XCTAssertNotNil(token);
+                   XCTAssertEqualObjects(token.token, expectedToken.token);
+                   XCTAssertNil(error);
+                 }];
   }
 
   // 3.3. Fulfill the pending promise to finish the get token operation.
@@ -468,12 +468,12 @@ static NSString *const kAppGroupID = @"app_group_id";
 
     // 3.2. Request token and verify result.
     [self.appCheck
-        getTokenForcingRefresh:NO
-                    completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
-                      [getTokenExpectation fulfill];
-                      XCTAssertNil(token);
-                      XCTAssertEqualObjects(error, storageError);
-                    }];
+        tokenForcingRefresh:NO
+                 completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
+                   [getTokenExpectation fulfill];
+                   XCTAssertNil(token);
+                   XCTAssertEqualObjects(error, storageError);
+                 }];
   }
 
   // 3.3. Reject the pending promise to finish the get token operation.
@@ -519,14 +519,14 @@ static NSString *const kAppGroupID = @"app_group_id";
       [self configuredExpectation_GetTokenWhenCacheTokenIsValid_withExpectedToken:cachedToken];
 
   // 2. Request token and verify result.
-  [self.appCheck getTokenForcingRefresh:NO
-                             completion:^(id<GACAppCheckTokenProtocol> _Nullable token,
-                                          NSError *_Nullable error) {
-                               [expectation fulfill];
-                               XCTAssertNotNil(token);
-                               XCTAssertEqualObjects(token.token, cachedToken.token);
-                               XCTAssertNil(error);
-                             }];
+  [self.appCheck tokenForcingRefresh:NO
+                          completion:^(id<GACAppCheckTokenProtocol> _Nullable token,
+                                       NSError *_Nullable error) {
+                            [expectation fulfill];
+                            XCTAssertNotNil(token);
+                            XCTAssertEqualObjects(token.token, cachedToken.token);
+                            XCTAssertNil(error);
+                          }];
 
   // 3. Wait for expectations and validate mocks.
   [self waitForExpectations:@[ expectation ] timeout:0.5];
@@ -542,13 +542,13 @@ static NSString *const kAppGroupID = @"app_group_id";
 
   // 2. Request token and verify result.
   [self.appCheck
-      getTokenForcingRefresh:NO
-                  completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
-                    [expectation fulfill];
-                    XCTAssertNotNil(token);
-                    XCTAssertEqualObjects(token.token, cachedToken.token);
-                    XCTAssertNil(error);
-                  }];
+      tokenForcingRefresh:NO
+               completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
+                 [expectation fulfill];
+                 XCTAssertNotNil(token);
+                 XCTAssertEqualObjects(token.token, cachedToken.token);
+                 XCTAssertNil(error);
+               }];
 
   // 3. Wait for expectations and validate mocks.
   [self waitForExpectations:@[ expectation ] timeout:0.5];


### PR DESCRIPTION
Renamed `getTokenForcingRefresh:completion:` to `tokenForcingRefresh:completion` and `getLimitedUseTokenWithCompletion:` to `limitedUseTokenWithCompletion:` since they behave like the [public API methods](https://github.com/firebase/firebase-ios-sdk/blob/009b87b7b4149aee1e61f13be0381fca765c2100/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h#L69-L83) of the same names in Firebase App Check (rather than the [interop methods](https://github.com/firebase/firebase-ios-sdk/blob/009b87b7b4149aee1e61f13be0381fca765c2100/FirebaseAppCheck/Interop/FIRAppCheckInterop.h#L30-L52)).