### PR TITLE
Consistently use `GACAppCheckTokenProtocol` in public API

### DIFF
--- a/AppCheckCore.podspec
+++ b/AppCheckCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AppCheckCore'
-  s.version          = '0.1.0-alpha.1'
+  s.version          = '0.1.0-alpha.4'
   s.summary          = 'App Check Core SDK.'
 
   s.description      = <<-DESC

--- a/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -33,6 +33,7 @@
 #import "AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.h"
 #import "AppCheckCore/Sources/Core/Backoff/GACAppCheckBackoffWrapper.h"
 #import "AppCheckCore/Sources/Core/GACAppCheckLogger+Internal.h"
+#import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckToken.h"
 
 #import "AppCheckCore/Sources/Core/Utils/GACAppCheckCryptoUtils.h"
 
@@ -190,11 +191,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - GACAppCheckProvider
 
-- (void)getTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable, NSError *_Nullable))handler {
+- (void)getTokenWithCompletion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable,
+                                         NSError *_Nullable))handler {
   [self getTokenWithLimitedUse:NO completion:handler];
 }
 
-- (void)getLimitedUseTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable,
+- (void)getLimitedUseTokenWithCompletion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable,
                                                    NSError *_Nullable))handler {
   [self getTokenWithLimitedUse:YES completion:handler];
 }
@@ -202,7 +204,8 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Internal
 
 - (void)getTokenWithLimitedUse:(BOOL)limitedUse
-                    completion:(void (^)(GACAppCheckToken *_Nullable, NSError *_Nullable))handler {
+                    completion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable,
+                                         NSError *_Nullable))handler {
   [self getTokenWithLimitedUse:limitedUse]
       // Call the handler with the result.
       .then(^FBLPromise *(GACAppCheckToken *token) {

--- a/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m
+++ b/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m
@@ -99,12 +99,12 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
 
 #pragma mark - GACAppCheckProvider
 
-- (void)getTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable token,
-                                         NSError *_Nullable error))handler {
+- (void)getTokenWithCompletion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable,
+                                         NSError *_Nullable))handler {
   [self getTokenWithLimitedUse:NO completion:handler];
 }
 
-- (void)getLimitedUseTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable,
+- (void)getLimitedUseTokenWithCompletion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable,
                                                    NSError *_Nullable))handler {
   [self getTokenWithLimitedUse:YES completion:handler];
 }

--- a/AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
+++ b/AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
@@ -90,12 +90,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - GACAppCheckProvider
 
-- (void)getTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable token,
-                                         NSError *_Nullable error))handler {
+- (void)getTokenWithCompletion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable,
+                                         NSError *_Nullable))handler {
   [self getTokenWithLimitedUse:NO completion:handler];
 }
 
-- (void)getLimitedUseTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable,
+- (void)getLimitedUseTokenWithCompletion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable,
                                                    NSError *_Nullable))handler {
   [self getTokenWithLimitedUse:YES completion:handler];
 }

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h
@@ -16,7 +16,6 @@
 
 #import <Foundation/Foundation.h>
 
-@class GACAppCheckToken;
 @protocol GACAppCheckProvider;
 @protocol GACAppCheckSettingsProtocol;
 @protocol GACAppCheckTokenDelegate;

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckProvider.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckProvider.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class GACAppCheckToken;
+@protocol GACAppCheckTokenProtocol;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -32,14 +32,14 @@ NS_SWIFT_NAME(AppCheckCoreProvider)
 /// @param handler The completion handler. Make sure to call the handler with either a token
 /// or an error.
 - (void)getTokenWithCompletion:
-    (void (^)(GACAppCheckToken *_Nullable token, NSError *_Nullable error))handler
+    (void (^)(id<GACAppCheckTokenProtocol> _Nullable token, NSError *_Nullable error))handler
     NS_SWIFT_NAME(getToken(completion:));
 
 /// Returns a new App Check token suitable for consumption in a limited-use scenario.
 /// @param handler The completion handler. Make sure to call the handler with either a token
 /// or an error.
 - (void)getLimitedUseTokenWithCompletion:
-    (void (^)(GACAppCheckToken *_Nullable token, NSError *_Nullable error))handler
+    (void (^)(id<GACAppCheckTokenProtocol> _Nullable token, NSError *_Nullable error))handler
     NS_SWIFT_NAME(getLimitedUseToken(completion:));
 
 @end

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckTokenDelegate.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckTokenDelegate.h
@@ -26,7 +26,7 @@ NS_SWIFT_NAME(AppCheckCoreTokenDelegate)
 /// @param token The updated App Check token.
 /// @param serviceName A unique identifier for the App Check instance, may be a Firebase App Name
 /// or an SDK name.
-- (void)tokenDidUpdate:(GACAppCheckToken *)token serviceName:(NSString *)serviceName;
+- (void)tokenDidUpdate:(id<GACAppCheckTokenProtocol>)token serviceName:(NSString *)serviceName;
 
 @end
 

--- a/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -194,11 +194,12 @@ final class AppCheckAPITests {
 }
 
 class DummyAppCheckProvider: NSObject, AppCheckCoreProvider {
-  func getToken(completion handler: @escaping (AppCheckCoreToken?, Error?) -> Void) {
+  func getToken(completion handler: @escaping (AppCheckCoreTokenProtocol?, Error?) -> Void) {
     handler(AppCheckCoreToken(token: "token", expirationDate: .distantFuture), nil)
   }
 
-  func getLimitedUseToken(completion handler: @escaping (AppCheckCoreToken?, Error?) -> Void) {
+  func getLimitedUseToken(completion handler: @escaping (AppCheckCoreTokenProtocol?, Error?)
+    -> Void) {
     handler(
       AppCheckCoreToken(token: "token", expirationDate: .init(timeIntervalSinceNow: 3600)),
       nil
@@ -211,5 +212,5 @@ class DummyAppCheckSettings: NSObject, AppCheckCoreSettingsProtocol {
 }
 
 class DummyAppCheckTokenDelegate: NSObject, AppCheckCoreTokenDelegate {
-  func tokenDidUpdate(_ token: AppCheckCoreToken, serviceName: String) {}
+  func tokenDidUpdate(_ token: AppCheckCoreTokenProtocol, serviceName: String) {}
 }


### PR DESCRIPTION
Replaced usages of `GACAppCheckToken *` with `id<GACAppCheckTokenProtocol>` in the public API for consistency -- some APIs already used the `GACAppCheckTokenProtocol` protocol (e.g., [`getTokenForcingRefresh:completion:`](https://github.com/google/app-check/blob/f85d46bd67c8a8af9a1ab29142a3fe84f50f4599/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h#L38)) while others used the `GACAppCheckToken` class type (e.g., [`getTokenWithCompletion:`](https://github.com/google/app-check/blob/f85d46bd67c8a8af9a1ab29142a3fe84f50f4599/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckProvider.h#L35)). Callers should only need the methods defined in the protocol.