### PR TITLE
Remove outdated `GACAppAttestProvider` constructor

### DIFF
--- a/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -142,22 +142,6 @@ NS_ASSUME_NONNULL_BEGIN
                              APIKey:(nullable NSString *)APIKey
                 keychainAccessGroup:(nullable NSString *)accessGroup
                        requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
-  return [self initWithServiceName:serviceName
-                      resourceName:resourceName
-                           baseURL:baseURL
-                            APIKey:APIKey
-               keychainAccessGroup:accessGroup
-                        limitedUse:NO
-                      requestHooks:requestHooks];
-}
-
-- (instancetype)initWithServiceName:(NSString *)serviceName
-                       resourceName:(NSString *)resourceName
-                            baseURL:(nullable NSString *)baseURL
-                             APIKey:(nullable NSString *)APIKey
-                keychainAccessGroup:(nullable NSString *)accessGroup
-                         limitedUse:(BOOL)limitedUse
-                       requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
   NSURLSession *URLSession = [NSURLSession
       sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
 

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppAttestProvider.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppAttestProvider.h
@@ -50,30 +50,6 @@ NS_SWIFT_NAME(AppCheckCoreAppAttestProvider)
                 keychainAccessGroup:(nullable NSString *)accessGroup
                        requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
 
-/// Initializer with support for short-lived tokens.
-///
-/// TODO(andrewheard): Remove or refactor this constructor when the short-lived (limited-use) token
-/// feature is fully implemented.
-///
-/// @param serviceName A unique identifier to differentiate storage keys corresponding to the same
-/// `resourceName`; may be a Firebase App Name or an SDK name.
-/// @param resourceName The name of the resource protected by App Check; for a Firebase App this is
-/// "projects/{project_id}/apps/{app_id}".
-/// @param baseURL The base URL for the App Check service; defaults to
-/// `https://firebaseappcheck.googleapis.com/v1` if nil.
-/// @param APIKey The Google Cloud Platform API key, if needed, or nil.
-/// @param accessGroup The Keychain Access Group.
-/// @param limitedUse If YES, forces a short-lived token with a 5 minute TTL.
-/// @param requestHooks Hooks that will be invoked on requests through this service.
-/// @return An instance of `AppAttestProvider`.
-- (instancetype)initWithServiceName:(NSString *)serviceName
-                       resourceName:(NSString *)resourceName
-                            baseURL:(nullable NSString *)baseURL
-                             APIKey:(nullable NSString *)APIKey
-                keychainAccessGroup:(nullable NSString *)accessGroup
-                         limitedUse:(BOOL)limitedUse
-                       requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
-
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Removed the `initWithServiceName:resourceName:baseURL:APIKey:keychainAccessGroup:limitedUse:requestHooks:` constructor for `GACAppAttestProvider`. As of PR https://github.com/google/app-check/pull/11, limited-use tokens should now be requested by calling [`getLimitedUseTokenWithCompletion:`](https://github.com/google/app-check/blob/2e2cc7f8df94b90c7a7f7cf37b2b55db1aeb492d/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckProvider.h#L38-L43).