### PR TITLE
Return `GACAppCheckTokenResult` in `tokenForcingRefresh` completion handler

### DIFF
--- a/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -175,12 +175,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - GACAppCheckProvider
 
-- (void)getTokenWithCompletion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable,
-                                         NSError *_Nullable))handler {
+- (void)getTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable, NSError *_Nullable))handler {
   [self getTokenWithLimitedUse:NO completion:handler];
 }
 
-- (void)getLimitedUseTokenWithCompletion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable,
+- (void)getLimitedUseTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable,
                                                    NSError *_Nullable))handler {
   [self getTokenWithLimitedUse:YES completion:handler];
 }
@@ -188,8 +187,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Internal
 
 - (void)getTokenWithLimitedUse:(BOOL)limitedUse
-                    completion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable,
-                                         NSError *_Nullable))handler {
+                    completion:(void (^)(GACAppCheckToken *_Nullable, NSError *_Nullable))handler {
   [self getTokenWithLimitedUse:limitedUse]
       // Call the handler with the result.
       .then(^FBLPromise *(GACAppCheckToken *token) {

--- a/AppCheckCore/Sources/Core/GACAppCheck.m
+++ b/AppCheckCore/Sources/Core/GACAppCheck.m
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 static const NSTimeInterval kTokenExpirationThreshold = 5 * 60;  // 5 min.
 
-typedef void (^GACAppCheckTokenHandler)(id<GACAppCheckTokenProtocol> _Nullable token,
+typedef void (^GACAppCheckTokenHandler)(GACAppCheckToken *_Nullable token,
                                         NSError *_Nullable error);
 
 @interface GACAppCheck ()
@@ -111,7 +111,7 @@ typedef void (^GACAppCheckTokenHandler)(id<GACAppCheckTokenProtocol> _Nullable t
 
 - (void)tokenForcingRefresh:(BOOL)forcingRefresh completion:(GACAppCheckTokenHandler)handler {
   [self retrieveOrRefreshTokenForcingRefresh:forcingRefresh]
-      .then(^id _Nullable(id<GACAppCheckTokenProtocol> token) {
+      .then(^id _Nullable(GACAppCheckToken *token) {
         handler(token, nil);
         return token;
       })
@@ -122,7 +122,7 @@ typedef void (^GACAppCheckTokenHandler)(id<GACAppCheckTokenProtocol> _Nullable t
 
 - (void)limitedUseTokenWithCompletion:(GACAppCheckTokenHandler)handler {
   [self limitedUseToken]
-      .then(^id _Nullable(id<GACAppCheckTokenProtocol> token) {
+      .then(^id _Nullable(GACAppCheckToken *token) {
         handler(token, nil);
         return token;
       })

--- a/AppCheckCore/Sources/Core/GACAppCheck.m
+++ b/AppCheckCore/Sources/Core/GACAppCheck.m
@@ -27,6 +27,7 @@
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckSettings.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckToken.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckTokenDelegate.h"
+#import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckTokenResult.h"
 
 #import "AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 #import "AppCheckCore/Sources/Core/GACAppCheckLogger+Internal.h"
@@ -109,14 +110,15 @@ typedef void (^GACAppCheckTokenHandler)(GACAppCheckToken *_Nullable token,
                      tokenDelegate:tokenDelegate];
 }
 
-- (void)tokenForcingRefresh:(BOOL)forcingRefresh completion:(GACAppCheckTokenHandler)handler {
+- (void)tokenForcingRefresh:(BOOL)forcingRefresh
+                 completion:(void (^)(GACAppCheckTokenResult *result))handler {
   [self retrieveOrRefreshTokenForcingRefresh:forcingRefresh]
       .then(^id _Nullable(GACAppCheckToken *token) {
-        handler(token, nil);
+        handler([[GACAppCheckTokenResult alloc] initWithToken:token]);
         return token;
       })
       .catch(^(NSError *_Nonnull error) {
-        handler(nil, error);
+        handler([[GACAppCheckTokenResult alloc] initWithError:error]);
       });
 }
 

--- a/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m
+++ b/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m
@@ -99,12 +99,11 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
 
 #pragma mark - GACAppCheckProvider
 
-- (void)getTokenWithCompletion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable,
-                                         NSError *_Nullable))handler {
+- (void)getTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable, NSError *_Nullable))handler {
   [self getTokenWithLimitedUse:NO completion:handler];
 }
 
-- (void)getLimitedUseTokenWithCompletion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable,
+- (void)getLimitedUseTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable,
                                                    NSError *_Nullable))handler {
   [self getTokenWithLimitedUse:YES completion:handler];
 }

--- a/AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
+++ b/AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
@@ -90,12 +90,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - GACAppCheckProvider
 
-- (void)getTokenWithCompletion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable,
-                                         NSError *_Nullable))handler {
+- (void)getTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable, NSError *_Nullable))handler {
   [self getTokenWithLimitedUse:NO completion:handler];
 }
 
-- (void)getLimitedUseTokenWithCompletion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable,
+- (void)getLimitedUseTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable,
                                                    NSError *_Nullable))handler {
   [self getTokenWithLimitedUse:YES completion:handler];
 }

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h
@@ -20,22 +20,23 @@
 @protocol GACAppCheckSettingsProtocol;
 @protocol GACAppCheckTokenDelegate;
 @class GACAppCheckToken;
+@class GACAppCheckTokenResult;
 
 NS_ASSUME_NONNULL_BEGIN
 
 NS_SWIFT_NAME(AppCheckCoreProtocol) @protocol GACAppCheckProtocol
 
-/// Requests Firebase app check token.
+/// Requests an App Check token.
 ///
 /// @param forcingRefresh If `YES`,  a new Firebase app check token is requested and the token
 /// cache is ignored. If `NO`, the cached token is used if it exists and has not expired yet. In
 /// most cases, `NO` should be used. `YES` should only be used if the server explicitly returns an
 /// error, indicating a revoked token.
-/// @param handler The completion handler. Includes the app check token if the request succeeds,
-/// or an error if the request fails.
+/// @param handler The completion handler to call when the token fetch request completes. The
+/// `result` parameter Includes the App Check token if the request succeeds, or a placeholder token
+/// and an error if the request fails.
 - (void)tokenForcingRefresh:(BOOL)forcingRefresh
-                 completion:
-                     (void (^)(GACAppCheckToken *_Nullable token, NSError *_Nullable error))handler
+                 completion:(void (^)(GACAppCheckTokenResult *result))handler
     NS_SWIFT_NAME(token(forcingRefresh:completion:));
 
 /// Retrieve a new limited-use App Check token

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h
@@ -19,7 +19,7 @@
 @protocol GACAppCheckProvider;
 @protocol GACAppCheckSettingsProtocol;
 @protocol GACAppCheckTokenDelegate;
-@protocol GACAppCheckTokenProtocol;
+@class GACAppCheckToken;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -34,15 +34,15 @@ NS_SWIFT_NAME(AppCheckCoreProtocol) @protocol GACAppCheckProtocol
 /// @param handler The completion handler. Includes the app check token if the request succeeds,
 /// or an error if the request fails.
 - (void)tokenForcingRefresh:(BOOL)forcingRefresh
-                 completion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable token,
-                                      NSError *_Nullable error))handler
+                 completion:
+                     (void (^)(GACAppCheckToken *_Nullable token, NSError *_Nullable error))handler
     NS_SWIFT_NAME(token(forcingRefresh:completion:));
 
 /// Retrieve a new limited-use App Check token
 ///
 /// This method does not affect the token generation behavior of the
 /// ``tokenForcingRefresh()`` method.
-- (void)limitedUseTokenWithCompletion:(void (^)(id<GACAppCheckTokenProtocol> _Nullable token,
+- (void)limitedUseTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable token,
                                                 NSError *_Nullable error))handler;
 
 @end

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckProvider.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckProvider.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-@protocol GACAppCheckTokenProtocol;
+@class GACAppCheckToken;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -32,14 +32,14 @@ NS_SWIFT_NAME(AppCheckCoreProvider)
 /// @param handler The completion handler. Make sure to call the handler with either a token
 /// or an error.
 - (void)getTokenWithCompletion:
-    (void (^)(id<GACAppCheckTokenProtocol> _Nullable token, NSError *_Nullable error))handler
+    (void (^)(GACAppCheckToken *_Nullable token, NSError *_Nullable error))handler
     NS_SWIFT_NAME(getToken(completion:));
 
 /// Returns a new App Check token suitable for consumption in a limited-use scenario.
 /// @param handler The completion handler. Make sure to call the handler with either a token
 /// or an error.
 - (void)getLimitedUseTokenWithCompletion:
-    (void (^)(id<GACAppCheckTokenProtocol> _Nullable token, NSError *_Nullable error))handler
+    (void (^)(GACAppCheckToken *_Nullable token, NSError *_Nullable error))handler
     NS_SWIFT_NAME(getLimitedUseToken(completion:));
 
 @end

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckToken.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckToken.h
@@ -18,10 +18,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NS_SWIFT_NAME(AppCheckCoreTokenProtocol)
-@protocol GACAppCheckTokenProtocol <NSObject>
+/// An object representing an App Check token.
+NS_SWIFT_NAME(AppCheckCoreToken)
+@interface GACAppCheckToken : NSObject
 
-/// A Firebase App Check token.
+/// The App Check token.
 @property(nonatomic, readonly) NSString *token;
 
 /// The App Check token's expiration date in the device's local time.
@@ -29,12 +30,6 @@ NS_SWIFT_NAME(AppCheckCoreTokenProtocol)
 
 /// The date when the App Check token was received in the device's local time.
 @property(nonatomic, readonly) NSDate *receivedAtDate;
-
-@end
-
-/// An object representing a Firebase App Check token.
-NS_SWIFT_NAME(AppCheckCoreToken)
-@interface GACAppCheckToken : NSObject <GACAppCheckTokenProtocol>
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckTokenDelegate.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckTokenDelegate.h
@@ -26,7 +26,7 @@ NS_SWIFT_NAME(AppCheckCoreTokenDelegate)
 /// @param token The updated App Check token.
 /// @param serviceName A unique identifier for the App Check instance, may be a Firebase App Name
 /// or an SDK name.
-- (void)tokenDidUpdate:(id<GACAppCheckTokenProtocol>)token serviceName:(NSString *)serviceName;
+- (void)tokenDidUpdate:(GACAppCheckToken *)token serviceName:(NSString *)serviceName;
 
 @end
 

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckTests.m
@@ -180,14 +180,13 @@ static NSString *const kAppGroupID = @"app_group_id";
       [self configuredExpectations_GetTokenWhenNoCache_withExpectedToken:expectedToken];
 
   // 2. Request token and verify result.
-  [self.appCheck
-      tokenForcingRefresh:NO
-               completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
-                 [expectation fulfill];
-                 XCTAssertNotNil(token);
-                 XCTAssertEqualObjects(token.token, expectedToken.token);
-                 XCTAssertNil(error);
-               }];
+  [self.appCheck tokenForcingRefresh:NO
+                          completion:^(GACAppCheckToken *_Nullable token, NSError *error) {
+                            [expectation fulfill];
+                            XCTAssertNotNil(token);
+                            XCTAssertEqualObjects(token.token, expectedToken.token);
+                            XCTAssertNil(error);
+                          }];
 
   // 3. Wait for expectations and validate mocks.
   [self waitForExpectations:@[ expectation ] timeout:0.5];
@@ -206,14 +205,13 @@ static NSString *const kAppGroupID = @"app_group_id";
                 expectedToken];
 
   // 2. Request token and verify result.
-  [self.appCheck
-      tokenForcingRefresh:YES
-               completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
-                 [expectation fulfill];
-                 XCTAssertNotNil(token);
-                 XCTAssertEqualObjects(token.token, expectedToken.token);
-                 XCTAssertNil(error);
-               }];
+  [self.appCheck tokenForcingRefresh:YES
+                          completion:^(GACAppCheckToken *_Nullable token, NSError *error) {
+                            [expectation fulfill];
+                            XCTAssertNotNil(token);
+                            XCTAssertEqualObjects(token.token, expectedToken.token);
+                            XCTAssertNil(error);
+                          }];
 
   // 3. Wait for expectations and validate mocks.
   [self waitForExpectations:@[ expectation ] timeout:0.5];
@@ -228,14 +226,13 @@ static NSString *const kAppGroupID = @"app_group_id";
       [self configuredExpectations_GetTokenWhenCachedTokenExpired_withExpectedToken:expectedToken];
 
   // 2. Request token and verify result.
-  [self.appCheck
-      tokenForcingRefresh:NO
-               completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
-                 [expectation fulfill];
-                 XCTAssertNotNil(token);
-                 XCTAssertEqualObjects(token.token, expectedToken.token);
-                 XCTAssertNil(error);
-               }];
+  [self.appCheck tokenForcingRefresh:NO
+                          completion:^(GACAppCheckToken *_Nullable token, NSError *error) {
+                            [expectation fulfill];
+                            XCTAssertNotNil(token);
+                            XCTAssertEqualObjects(token.token, expectedToken.token);
+                            XCTAssertNil(error);
+                          }];
 
   // 3. Wait for expectations and validate mocks.
   [self waitForExpectations:@[ expectation ] timeout:0.5];
@@ -251,15 +248,14 @@ static NSString *const kAppGroupID = @"app_group_id";
       [self configuredExpectations_GetTokenWhenError_withError:providerError andToken:cachedToken];
 
   // 2. Request token and verify result.
-  [self.appCheck
-      tokenForcingRefresh:NO
-               completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
-                 [expectation fulfill];
-                 XCTAssertNil(token);
-                 XCTAssertEqualObjects(error, providerError);
-                 // Interop API does not wrap errors in public domain.
-                 XCTAssertNotEqualObjects(error.domain, GACAppCheckErrorDomain);
-               }];
+  [self.appCheck tokenForcingRefresh:NO
+                          completion:^(GACAppCheckToken *_Nullable token, NSError *error) {
+                            [expectation fulfill];
+                            XCTAssertNil(token);
+                            XCTAssertEqualObjects(error, providerError);
+                            // Interop API does not wrap errors in public domain.
+                            XCTAssertNotEqualObjects(error.domain, GACAppCheckErrorDomain);
+                          }];
 
   // 3. Wait for expectations and validate mocks.
   [self waitForExpectations:@[ expectation ] timeout:0.5];
@@ -355,13 +351,13 @@ static NSString *const kAppGroupID = @"app_group_id";
   // 5. Expect token request to be completed.
   XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
 
-  [self.appCheck limitedUseTokenWithCompletion:^(id<GACAppCheckTokenProtocol> _Nullable token,
-                                                 NSError *_Nullable error) {
-    [getTokenExpectation fulfill];
-    XCTAssertNotNil(token);
-    XCTAssertEqualObjects(token.token, expectedToken.token);
-    XCTAssertNil(error);
-  }];
+  [self.appCheck
+      limitedUseTokenWithCompletion:^(GACAppCheckToken *_Nullable token, NSError *_Nullable error) {
+        [getTokenExpectation fulfill];
+        XCTAssertNotNil(token);
+        XCTAssertEqualObjects(token.token, expectedToken.token);
+        XCTAssertNil(error);
+      }];
   [self waitForExpectations:@[ getTokenExpectation ] timeout:0.5];
   [self verifyAllMocks];
 }
@@ -384,14 +380,14 @@ static NSString *const kAppGroupID = @"app_group_id";
   // 5. Expect token request to be completed.
   XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
 
-  [self.appCheck limitedUseTokenWithCompletion:^(id<GACAppCheckTokenProtocol> _Nullable token,
-                                                 NSError *_Nullable error) {
-    [getTokenExpectation fulfill];
-    XCTAssertNotNil(error);
-    XCTAssertNil(token.token);
-    XCTAssertEqualObjects(error, providerError);
-    XCTAssertEqualObjects(error.domain, GACAppCheckErrorDomain);
-  }];
+  [self.appCheck
+      limitedUseTokenWithCompletion:^(GACAppCheckToken *_Nullable token, NSError *_Nullable error) {
+        [getTokenExpectation fulfill];
+        XCTAssertNotNil(error);
+        XCTAssertNil(token.token);
+        XCTAssertEqualObjects(error, providerError);
+        XCTAssertEqualObjects(error.domain, GACAppCheckErrorDomain);
+      }];
 
   [self waitForExpectations:@[ getTokenExpectation ] timeout:0.5];
   [self verifyAllMocks];
@@ -422,14 +418,13 @@ static NSString *const kAppGroupID = @"app_group_id";
     [getTokenCompletionExpectations addObject:getTokenExpectation];
 
     // 3.2. Request token and verify result.
-    [self.appCheck
-        tokenForcingRefresh:NO
-                 completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
-                   [getTokenExpectation fulfill];
-                   XCTAssertNotNil(token);
-                   XCTAssertEqualObjects(token.token, expectedToken.token);
-                   XCTAssertNil(error);
-                 }];
+    [self.appCheck tokenForcingRefresh:NO
+                            completion:^(GACAppCheckToken *_Nullable token, NSError *error) {
+                              [getTokenExpectation fulfill];
+                              XCTAssertNotNil(token);
+                              XCTAssertEqualObjects(token.token, expectedToken.token);
+                              XCTAssertNil(error);
+                            }];
   }
 
   // 3.3. Fulfill the pending promise to finish the get token operation.
@@ -467,13 +462,12 @@ static NSString *const kAppGroupID = @"app_group_id";
     [getTokenCompletionExpectations addObject:getTokenExpectation];
 
     // 3.2. Request token and verify result.
-    [self.appCheck
-        tokenForcingRefresh:NO
-                 completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
-                   [getTokenExpectation fulfill];
-                   XCTAssertNil(token);
-                   XCTAssertEqualObjects(error, storageError);
-                 }];
+    [self.appCheck tokenForcingRefresh:NO
+                            completion:^(GACAppCheckToken *_Nullable token, NSError *error) {
+                              [getTokenExpectation fulfill];
+                              XCTAssertNil(token);
+                              XCTAssertEqualObjects(error, storageError);
+                            }];
   }
 
   // 3.3. Reject the pending promise to finish the get token operation.
@@ -519,14 +513,14 @@ static NSString *const kAppGroupID = @"app_group_id";
       [self configuredExpectation_GetTokenWhenCacheTokenIsValid_withExpectedToken:cachedToken];
 
   // 2. Request token and verify result.
-  [self.appCheck tokenForcingRefresh:NO
-                          completion:^(id<GACAppCheckTokenProtocol> _Nullable token,
-                                       NSError *_Nullable error) {
-                            [expectation fulfill];
-                            XCTAssertNotNil(token);
-                            XCTAssertEqualObjects(token.token, cachedToken.token);
-                            XCTAssertNil(error);
-                          }];
+  [self.appCheck
+      tokenForcingRefresh:NO
+               completion:^(GACAppCheckToken *_Nullable token, NSError *_Nullable error) {
+                 [expectation fulfill];
+                 XCTAssertNotNil(token);
+                 XCTAssertEqualObjects(token.token, cachedToken.token);
+                 XCTAssertNil(error);
+               }];
 
   // 3. Wait for expectations and validate mocks.
   [self waitForExpectations:@[ expectation ] timeout:0.5];
@@ -541,14 +535,13 @@ static NSString *const kAppGroupID = @"app_group_id";
       [self configuredExpectation_GetTokenWhenCacheTokenIsValid_withExpectedToken:cachedToken];
 
   // 2. Request token and verify result.
-  [self.appCheck
-      tokenForcingRefresh:NO
-               completion:^(id<GACAppCheckTokenProtocol> _Nullable token, NSError *error) {
-                 [expectation fulfill];
-                 XCTAssertNotNil(token);
-                 XCTAssertEqualObjects(token.token, cachedToken.token);
-                 XCTAssertNil(error);
-               }];
+  [self.appCheck tokenForcingRefresh:NO
+                          completion:^(GACAppCheckToken *_Nullable token, NSError *error) {
+                            [expectation fulfill];
+                            XCTAssertNotNil(token);
+                            XCTAssertEqualObjects(token.token, cachedToken.token);
+                            XCTAssertNil(error);
+                          }];
 
   // 3. Wait for expectations and validate mocks.
   [self waitForExpectations:@[ expectation ] timeout:0.5];

--- a/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -61,10 +61,12 @@ final class AppCheckAPITests {
     )
 
     // Get token
-    appCheck.token(forcingRefresh: false) { token, error in
-      if let _ /* error */ = error {
+    appCheck.token(forcingRefresh: false) { result in
+      if let _ /* error */ = result.error {
+        _ /* placeholder token */ = result.token
         // ...
-      } else if let _ /* token */ = token {
+      } else {
+        _ /* token */ = result.token
         // ...
       }
     }
@@ -73,9 +75,12 @@ final class AppCheckAPITests {
     if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
       // async/await is only available on iOS 13+
       Task {
-        do {
-          try await appCheck.token(forcingRefresh: false)
-        } catch {
+        let result = await appCheck.token(forcingRefresh: false)
+        if let _ /* error */ = result.error {
+          _ /* placeholder token */ = result.token
+          // ...
+        } else {
+          _ /* token */ = result.token
           // ...
         }
       }
@@ -123,8 +128,8 @@ final class AppCheckAPITests {
 
     // MARK: - AppCheckErrors
 
-    appCheck.token(forcingRefresh: false) { _, error in
-      if let error = error {
+    appCheck.token(forcingRefresh: false) { result in
+      if let error = result.error {
         switch error {
         case AppCheckCoreErrorCode.unknown:
           break

--- a/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -194,11 +194,11 @@ final class AppCheckAPITests {
 }
 
 class DummyAppCheckProvider: NSObject, AppCheckCoreProvider {
-  func getToken(completion handler: @escaping (AppCheckCoreTokenProtocol?, Error?) -> Void) {
+  func getToken(completion handler: @escaping (AppCheckCoreToken?, Error?) -> Void) {
     handler(AppCheckCoreToken(token: "token", expirationDate: .distantFuture), nil)
   }
 
-  func getLimitedUseToken(completion handler: @escaping (AppCheckCoreTokenProtocol?, Error?)
+  func getLimitedUseToken(completion handler: @escaping (AppCheckCoreToken?, Error?)
     -> Void) {
     handler(
       AppCheckCoreToken(token: "token", expirationDate: .init(timeIntervalSinceNow: 3600)),
@@ -212,5 +212,5 @@ class DummyAppCheckSettings: NSObject, AppCheckCoreSettingsProtocol {
 }
 
 class DummyAppCheckTokenDelegate: NSObject, AppCheckCoreTokenDelegate {
-  func tokenDidUpdate(_ token: AppCheckCoreTokenProtocol, serviceName: String) {}
+  func tokenDidUpdate(_ token: AppCheckCoreToken, serviceName: String) {}
 }


### PR DESCRIPTION
Updated the `tokenForcingRefresh:completion:` method to return a `GACAppCheckTokenResult *` instead of `GACAppCheckToken *_Nullable token, NSError *_Nullable error`. This allows a placeholder token to be returned alongside the error on failure.

Removed references to "Interop" in `GACAppCheckTests` (this was leftover when splitting up Firebase App Check).

Note: `limitedUseTokenWithCompletion:` will be updated in a follow-up PR.