### PR TITLE
Return `GACAppCheckTokenResult` in `limitedUseTokenWithCompletion` handler

### DIFF
--- a/AppCheckCore/Sources/Core/GACAppCheck.m
+++ b/AppCheckCore/Sources/Core/GACAppCheck.m
@@ -39,8 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 static const NSTimeInterval kTokenExpirationThreshold = 5 * 60;  // 5 min.
 
-typedef void (^GACAppCheckTokenHandler)(GACAppCheckToken *_Nullable token,
-                                        NSError *_Nullable error);
+typedef void (^GACAppCheckTokenHandler)(GACAppCheckTokenResult *result);
 
 @interface GACAppCheck ()
 
@@ -110,8 +109,7 @@ typedef void (^GACAppCheckTokenHandler)(GACAppCheckToken *_Nullable token,
                      tokenDelegate:tokenDelegate];
 }
 
-- (void)tokenForcingRefresh:(BOOL)forcingRefresh
-                 completion:(void (^)(GACAppCheckTokenResult *result))handler {
+- (void)tokenForcingRefresh:(BOOL)forcingRefresh completion:(GACAppCheckTokenHandler)handler {
   [self retrieveOrRefreshTokenForcingRefresh:forcingRefresh]
       .then(^id _Nullable(GACAppCheckToken *token) {
         handler([[GACAppCheckTokenResult alloc] initWithToken:token]);
@@ -125,11 +123,11 @@ typedef void (^GACAppCheckTokenHandler)(GACAppCheckToken *_Nullable token,
 - (void)limitedUseTokenWithCompletion:(GACAppCheckTokenHandler)handler {
   [self limitedUseToken]
       .then(^id _Nullable(GACAppCheckToken *token) {
-        handler(token, nil);
+        handler([[GACAppCheckTokenResult alloc] initWithToken:token]);
         return token;
       })
       .catch(^(NSError *_Nonnull error) {
-        handler(nil, error);
+        handler([[GACAppCheckTokenResult alloc] initWithError:error]);
       });
 }
 

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h
@@ -33,7 +33,7 @@ NS_SWIFT_NAME(AppCheckCoreProtocol) @protocol GACAppCheckProtocol
 /// most cases, `NO` should be used. `YES` should only be used if the server explicitly returns an
 /// error, indicating a revoked token.
 /// @param handler The completion handler to call when the token fetch request completes. The
-/// `result` parameter Includes the App Check token if the request succeeds, or a placeholder token
+/// `result` parameter includes the App Check token if the request succeeds, or a placeholder token
 /// and an error if the request fails.
 - (void)tokenForcingRefresh:(BOOL)forcingRefresh
                  completion:(void (^)(GACAppCheckTokenResult *result))handler
@@ -45,7 +45,7 @@ NS_SWIFT_NAME(AppCheckCoreProtocol) @protocol GACAppCheckProtocol
 /// ``tokenForcingRefresh()`` method.
 ///
 /// @param handler The completion handler to call when the token fetch request completes. The
-/// `result` parameter Includes the App Check token if the request succeeds, or a placeholder token
+/// `result` parameter includes the App Check token if the request succeeds, or a placeholder token
 /// and an error if the request fails.
 - (void)limitedUseTokenWithCompletion:(void (^)(GACAppCheckTokenResult *result))handler;
 

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h
@@ -43,8 +43,11 @@ NS_SWIFT_NAME(AppCheckCoreProtocol) @protocol GACAppCheckProtocol
 ///
 /// This method does not affect the token generation behavior of the
 /// ``tokenForcingRefresh()`` method.
-- (void)limitedUseTokenWithCompletion:(void (^)(GACAppCheckToken *_Nullable token,
-                                                NSError *_Nullable error))handler;
+///
+/// @param handler The completion handler to call when the token fetch request completes. The
+/// `result` parameter Includes the App Check token if the request succeeds, or a placeholder token
+/// and an error if the request fails.
+- (void)limitedUseTokenWithCompletion:(void (^)(GACAppCheckTokenResult *result))handler;
 
 @end
 

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckTests.m
@@ -345,13 +345,11 @@ static NSString *const kAppGroupID = @"app_group_id";
   // 5. Expect token request to be completed.
   XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
 
-  [self.appCheck
-      limitedUseTokenWithCompletion:^(GACAppCheckToken *_Nullable token, NSError *_Nullable error) {
-        [getTokenExpectation fulfill];
-        XCTAssertNotNil(token);
-        XCTAssertEqualObjects(token.token, expectedToken.token);
-        XCTAssertNil(error);
-      }];
+  [self.appCheck limitedUseTokenWithCompletion:^(GACAppCheckTokenResult *result) {
+    [getTokenExpectation fulfill];
+    XCTAssertEqualObjects(result.token, expectedToken);
+    XCTAssertNil(result.error);
+  }];
   [self waitForExpectations:@[ getTokenExpectation ] timeout:0.5];
   [self verifyAllMocks];
 }
@@ -374,14 +372,13 @@ static NSString *const kAppGroupID = @"app_group_id";
   // 5. Expect token request to be completed.
   XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
 
-  [self.appCheck
-      limitedUseTokenWithCompletion:^(GACAppCheckToken *_Nullable token, NSError *_Nullable error) {
-        [getTokenExpectation fulfill];
-        XCTAssertNotNil(error);
-        XCTAssertNil(token.token);
-        XCTAssertEqualObjects(error, providerError);
-        XCTAssertEqualObjects(error.domain, GACAppCheckErrorDomain);
-      }];
+  [self.appCheck limitedUseTokenWithCompletion:^(GACAppCheckTokenResult *result) {
+    [getTokenExpectation fulfill];
+    XCTAssertEqualObjects(result.token.token, kPlaceholderTokenValue);
+    XCTAssertNotNil(result.error);
+    XCTAssertEqualObjects(result.error, providerError);
+    XCTAssertEqualObjects(result.error.domain, GACAppCheckErrorDomain);
+  }];
 
   [self waitForExpectations:@[ getTokenExpectation ] timeout:0.5];
   [self verifyAllMocks];

--- a/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -86,6 +86,32 @@ final class AppCheckAPITests {
       }
     }
 
+    // Get limited-use token
+    appCheck.limitedUseToken { result in
+      if let _ /* error */ = result.error {
+        _ /* placeholder token */ = result.token
+        // ...
+      } else {
+        _ /* token */ = result.token
+        // ...
+      }
+    }
+
+    // Get limited-use token (async/await)
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is only available on iOS 13+
+      Task {
+        let result = await appCheck.limitedUseToken()
+        if let _ /* error */ = result.error {
+          _ /* placeholder token */ = result.token
+          // ...
+        } else {
+          _ /* token */ = result.token
+          // ...
+        }
+      }
+    }
+
     // MARK: - `AppCheckDebugProvider`
 
     // `AppCheckDebugProvider` initializer


### PR DESCRIPTION
Updated the `limitedUseTokenWithCompletion:` method to return a `GACAppCheckTokenResult *` instead of `GACAppCheckToken *_Nullable token, NSError *_Nullable error`. This allows a placeholder token to be returned alongside the error on failure.

Added Swift API tests for `limitedUseTokenWithCompletion:`.