### PR TITLE
Add `baseURL` parameter to `GACAppCheckDebugProvider` constructor

### DIFF
--- a/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m
+++ b/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m
@@ -52,6 +52,7 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
 
 - (instancetype)initWithServiceName:(NSString *)serviceName
                        resourceName:(NSString *)resourceName
+                            baseURL:(nullable NSString *)baseURL
                              APIKey:(nullable NSString *)APIKey
                        requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
   NSURLSession *URLSession = [NSURLSession
@@ -59,7 +60,7 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
 
   GACAppCheckAPIService *APIService =
       [[GACAppCheckAPIService alloc] initWithURLSession:URLSession
-                                                baseURL:nil
+                                                baseURL:baseURL
                                                  APIKey:APIKey
                                            requestHooks:requestHooks];
 

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckDebugProvider.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckDebugProvider.h
@@ -68,11 +68,14 @@ NS_SWIFT_NAME(AppCheckCoreDebugProvider)
 /// `resourceName`; may be a Firebase App Name or an SDK name.
 /// @param resourceName The name of the resource protected by App Check; for a Firebase App this is
 /// "projects/{project_id}/apps/{app_id}".
+/// @param baseURL The base URL for the App Check service; defaults to
+/// `https://firebaseappcheck.googleapis.com/v1` if nil.
 /// @param APIKey The Google Cloud Platform API key, if needed, or nil.
 /// @param requestHooks Hooks that will be invoked on requests through this service.
 /// @return An instance of `AppCheckDebugProvider` .
 - (instancetype)initWithServiceName:(NSString *)serviceName
                        resourceName:(NSString *)resourceName
+                            baseURL:(nullable NSString *)baseURL
                              APIKey:(nullable NSString *)APIKey
                        requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
 

--- a/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -119,6 +119,7 @@ final class AppCheckAPITests {
     let debugProvider = AppCheckCoreDebugProvider(
       serviceName: serviceName,
       resourceName: resourceName,
+      baseURL: nil,
       apiKey: apiKey,
       requestHooks: nil
     )


### PR DESCRIPTION
Added a `baseURL` parameter to `GACAppCheckDebugProvider` that offers the same functionality as the one in [`GACAppAttestProvider`](https://github.com/google/app-check/blob/f77879ca7581666d9fe0da7b5b27c34196acd902/AppCheckCore/Sources/Public/AppCheckCore/GACAppAttestProvider.h#L40-L48). This optionally allows the `https://firebaseappcheck.googleapis.com/v1beta` endpoint to be used instead of the default (`https://firebaseappcheck.googleapis.com/v1`).