### PR TITLE
Set default log level in `load` instead of getter

### DIFF
--- a/AppCheckCore/Sources/Core/GACAppCheckLogger.m
+++ b/AppCheckCore/Sources/Core/GACAppCheckLogger.m
@@ -27,14 +27,13 @@ NS_ASSUME_NONNULL_BEGIN
 // Note: Declared as volatile to make getting and setting atomic.
 static volatile GACAppCheckLogLevel _logLevel;
 
++ (void)load {
+  // Set the default log level (warning).
+  _logLevel = GACAppCheckLogLevelWarning;
+  NSLog(@"Set default log level");
+}
+
 + (GACAppCheckLogLevel)logLevel {
-  static dispatch_once_t once;
-  dispatch_once(&once, ^{
-    if (!_logLevel) {
-      // Set the default log level (warning) if not yet set.
-      _logLevel = GACAppCheckLogLevelWarning;
-    }
-  });
   return _logLevel;
 }
 

--- a/AppCheckCore/Sources/Core/GACAppCheckLogger.m
+++ b/AppCheckCore/Sources/Core/GACAppCheckLogger.m
@@ -30,7 +30,6 @@ static volatile GACAppCheckLogLevel _logLevel;
 + (void)load {
   // Set the default log level (warning).
   _logLevel = GACAppCheckLogLevelWarning;
-  NSLog(@"Set default log level");
 }
 
 + (GACAppCheckLogLevel)logLevel {

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckLoggerTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckLoggerTests.m
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import XCTest;
+
+#import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckLogger.h"
+
+@interface GACAppCheckLoggerTests : XCTestCase
+@end
+
+@implementation GACAppCheckLoggerTests
+
+- (void)testDefaultLogLevel {
+  GACAppCheckLogLevel defaultLogLevel = GACAppCheckLogger.logLevel;
+
+  XCTAssertEqual(defaultLogLevel, GACAppCheckLogLevelWarning);
+}
+
+- (void)testSetLogLevel {
+  GACAppCheckLogLevel expectedLogLevel = GACAppCheckLogLevelDebug;
+
+  GACAppCheckLogger.logLevel = expectedLogLevel;
+
+  XCTAssertEqual(GACAppCheckLogger.logLevel, expectedLogLevel);
+}
+
+@end


### PR DESCRIPTION
Moved setting the default logging level from the `logLevel` getter to `load` and added unit tests.