### PR TITLE
Rename debug token environment variable key

### DIFF
--- a/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m
+++ b/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m
@@ -125,7 +125,7 @@ static NSString *_Nullable StoredDebugToken() {
   return [[NSUserDefaults standardUserDefaults] stringForKey:kDebugTokenUserDefaultsKey];
 }
 
-static NSString *_Nullable GenerateAndStoreDebugToken() {
+static NSString *GenerateAndStoreDebugToken() {
   NSString *token = [NSUUID UUID].UUIDString;
   [[NSUserDefaults standardUserDefaults] setObject:token forKey:kDebugTokenUserDefaultsKey];
   return token;

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckErrors.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckErrors.h
@@ -48,7 +48,10 @@ typedef NS_ENUM(NSInteger, GACAppCheckMessageCode) {
   GACLoggerAppCheckMessageCodeUnexpectedHTTPCode = 3001,
 
   // Debug Provider
-  GACLoggerAppCheckMessageDebugProviderFailedExchange = 4002,
+  GACLoggerAppCheckMessageLocalDebugToken = 4001,
+  GACLoggerAppCheckMessageEnvironmentVariableDebugToken = 4002,
+  GACLoggerAppCheckMessageDebugProviderFirebaseEnvironmentVariable = 4003,
+  GACLoggerAppCheckMessageDebugProviderFailedExchange = 4004,
 
   // App Attest Provider
   GACLoggerAppCheckMessageCodeAppAttestNotSupported = 7001,


### PR DESCRIPTION
Renamed the primary debug token environment variable key from `FIRAAppCheckDebugToken` to `AppCheckDebugToken`. This continues to support `FIRAAppCheckDebugToken` as a fallback.