### PR TITLE
Update `GACAppCheckDebugProvider` documentation

### DIFF
--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckDebugProvider.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckDebugProvider.h
@@ -20,44 +20,34 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// A Firebase App Check provider that can exchange a debug token registered
-/// in the Firebase console for a Firebase App Check token. The debug provider
-/// is designed to enable testing applications on a simulator or test
-/// environment.
+/// An App Check provider that can exchange a debug token registered in the Firebase console for an
+/// App Check token. The debug provider is designed to enable testing applications on a simulator or
+/// in a test environment.
 ///
-/// NOTE: Do not use the debug provider in applications used by real users.
+/// NOTE: Do not use the debug provider in production applications used by real users.
 ///
-/// WARNING: Keep the Firebase App Check debug token secret. If you
-/// accidentally share one (e.g. commit to a public source repo), remove it in
-/// the Firebase console ASAP.
+/// WARNING: Keep the App Check debug token secret. If you accidentally share one (e.g., commit it
+/// to a public source repository), remove it in the Firebase console ASAP.
 ///
-/// To use `AppCheckDebugProvider` on a local simulator:
-/// 1. Configure `AppCheckDebugProviderFactory` before `FirebaseApp.configure()`:
-///    ```AppCheck.setAppCheckProviderFactory(AppCheckDebugProviderFactory())```
-/// 2. Enable debug logging by adding the `-FIRDebugEnabled` launch argument to
-///    the app target.
-/// 3. Launch the app. A local debug token will be logged when Firebase is
-///    configured. For example:
-/// "[Firebase/AppCheck][I-FAA001001] Firebase App Check Debug Token:
-/// '3BA09C8C-8A0D-4030-ACD5-B96D99DB73F9'".
-/// 4. Register the debug token in the Firebase console.
+/// To use `AppCheckCoreDebugProvider` on a local simulator:
+/// 1. Launch the app. A local debug token will be logged when the `AppCheckCoreDebugProvider` is
+///    instantiated. For example:
+///    "[AppCheckCore][I-GAC004001] App Check debug token: 'AB12C3D4-56EF-789G-01H2-IJ234567K8L9'."
+/// 2. Register the debug token in the Firebase console.
 ///
-/// Once the debug token is registered the debug provider will be able to provide a valid Firebase
-/// App Check token.
+/// Once the debug token is registered in the Firebase console, the debug provider will be able to
+/// provide a valid App Check token.
 ///
-/// To use `AppCheckDebugProvider` on a simulator on a build server:
-/// 1. Create a new Firebase App Check debug token in the Firebase console
-/// 2. Add the debug token to the secure storage of your build environment. E.g. see [Encrypted
-/// secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) for GitHub Actions,
-/// etc.
-/// 3. Configure  `AppCheckDebugProviderFactory` before `FirebaseApp.configure()`
-/// `AppCheck.setAppCheckProviderFactory(AppCheckDebugProviderFactory())`
-/// 4. Add an environment variable to the scheme with a name `FIRAAppCheckDebugToken` and value like
-/// `$(MY_APP_CHECK_DEBUG_TOKEN)`.
-/// 5. Configure the build script to pass the debug token as the environment variable, e.g.:
-/// `xcodebuild test -scheme InstallationsExample -workspace InstallationsExample.xcworkspace \
-/// MY_APP_CHECK_DEBUG_TOKEN=$(MY_SECRET_ON_CI)`
-///
+/// To use `AppCheckCoreDebugProvider` in a Continuous Integration (CI) environment:
+/// 1. Create a new App Check debug token in the Firebase console.
+/// 2. Add the debug token to the secure storage of your build environment. E.g., see
+///    [Encrypted secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) for
+///    GitHub Actions.
+/// 4. Add an environment variable to the scheme with a name `AppCheckDebugToken` and a value like
+///    `$(MY_APP_CHECK_DEBUG_TOKEN)`.
+/// 5. Configure the build script to pass the debug token as in environment variable, e.g.:
+///    `xcodebuild test -scheme InstallationsExample -workspace InstallationsExample.xcworkspace \
+///      MY_APP_CHECK_DEBUG_TOKEN=$(MY_SECRET_ON_CI)`
 NS_SWIFT_NAME(AppCheckCoreDebugProvider)
 @interface GACAppCheckDebugProvider : NSObject <GACAppCheckProvider>
 
@@ -72,23 +62,25 @@ NS_SWIFT_NAME(AppCheckCoreDebugProvider)
 /// `https://firebaseappcheck.googleapis.com/v1` if nil.
 /// @param APIKey The Google Cloud Platform API key, if needed, or nil.
 /// @param requestHooks Hooks that will be invoked on requests through this service.
-/// @return An instance of `AppCheckDebugProvider` .
+/// @return An instance of `AppCheckCoreDebugProvider` .
 - (instancetype)initWithServiceName:(NSString *)serviceName
                        resourceName:(NSString *)resourceName
                             baseURL:(nullable NSString *)baseURL
                              APIKey:(nullable NSString *)APIKey
                        requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
 
-/** Return the locally generated token. */
+/// Returns the locally generated token.
 - (NSString *)localDebugToken;
 
-/** Returns the currently used App Check debug token. The priority:
- *  - `FIRAAppCheckDebugToken` env variable value
- *  - A previously generated token, stored locally on the device
- *  - A newly generated random token. The generated token will be stored
- *    locally for future use
- * @return The currently used App Check debug token.
- */
+/// Returns the currently used App Check debug token.
+///
+/// The priority of the token used is:
+/// 1. The `AppCheckDebugToken` environment variable value
+/// 2. The `FIRAAppCheckDebugToken` environment variable value
+/// 3. A previously generated token, stored locally on the device
+/// 4. A newly generated random token. The generated token will be stored locally for future use
+///
+/// @return The currently used App Check debug token.
 - (NSString *)currentDebugToken;
 
 @end


### PR DESCRIPTION
Replaced the Firebase App Check documentation in `GACAppCheckDebugProvider` with updated instructions for App Check Core.