### PR TITLE
Make API key nonnull in DeviceCheck and debug providers

### DIFF
--- a/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m
+++ b/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m
@@ -53,7 +53,7 @@ static NSString *const kDebugTokenUserDefaultsKey = @"GACAppCheckDebugToken";
 - (instancetype)initWithServiceName:(NSString *)serviceName
                        resourceName:(NSString *)resourceName
                             baseURL:(nullable NSString *)baseURL
-                             APIKey:(nullable NSString *)APIKey
+                             APIKey:(NSString *)APIKey
                        requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
   NSURLSession *URLSession = [NSURLSession
       sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];

--- a/AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
+++ b/AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithServiceName:(NSString *)serviceName
                        resourceName:(NSString *)resourceName
-                             APIKey:(nullable NSString *)APIKey
+                             APIKey:(NSString *)APIKey
                        requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
   NSURLSession *URLSession = [NSURLSession
       sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckDebugProvider.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckDebugProvider.h
@@ -60,13 +60,13 @@ NS_SWIFT_NAME(AppCheckCoreDebugProvider)
 /// "projects/{project_id}/apps/{app_id}".
 /// @param baseURL The base URL for the App Check service; defaults to
 /// `https://firebaseappcheck.googleapis.com/v1` if nil.
-/// @param APIKey The Google Cloud Platform API key, if needed, or nil.
+/// @param APIKey The Google Cloud Platform API key.
 /// @param requestHooks Hooks that will be invoked on requests through this service.
-/// @return An instance of `AppCheckCoreDebugProvider` .
+/// @return An instance of `AppCheckCoreDebugProvider`.
 - (instancetype)initWithServiceName:(NSString *)serviceName
                        resourceName:(NSString *)resourceName
                             baseURL:(nullable NSString *)baseURL
-                             APIKey:(nullable NSString *)APIKey
+                             APIKey:(NSString *)APIKey
                        requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
 
 /// Returns the locally generated token.

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACDeviceCheckProvider.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACDeviceCheckProvider.h
@@ -39,12 +39,12 @@ NS_SWIFT_NAME(AppCheckCoreDeviceCheckProvider)
 /// `resourceName`; may be a Firebase App Name or an SDK name.
 /// @param resourceName The name of the resource protected by App Check; for a Firebase App this is
 /// "projects/{project_id}/apps/{app_id}".
-/// @param APIKey The Google Cloud Platform API key, if needed, or nil.
+/// @param APIKey The Google Cloud Platform API key.
 /// @param requestHooks Hooks that will be invoked on requests through this service.
-/// @return An instance of `DeviceCheckProvider` .
+/// @return An instance of `AppCheckCoreDeviceCheckProvider`.
 - (instancetype)initWithServiceName:(NSString *)serviceName
                        resourceName:(NSString *)resourceName
-                             APIKey:(nullable NSString *)APIKey
+                             APIKey:(NSString *)APIKey
                        requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
 
 @end


### PR DESCRIPTION
Updated the constructors for `GACAppCheckDebugProvider` and `GACDeviceCheckProvider` to make the `APIKey` parameter `nonnull`. The App Attest provider (unchanged) is the only one that can be used without an API key.