### PR TITLE
Update AppCheckCore.podspec version to `0.1.0-alpha.8`

### DIFF
--- a/AppCheckCore.podspec
+++ b/AppCheckCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AppCheckCore'
-  s.version          = '0.1.0-alpha.4'
+  s.version          = '0.1.0-alpha.8'
   s.summary          = 'App Check Core SDK.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
This is already pushed to https://github.com/firebase/SpecsDev/blob/9903a79155bf521b35f7f0fbc25bb40a731b1da4/AppCheckCore/0.1.0-alpha.8/AppCheckCore.podspec -- this just checks in the latest semantic version for reference.