### PR TITLE
Fix C function warnings in Xcode 14.3+

### DIFF
--- a/AppCheckCore/Sources/Core/GACAppCheckLogger.m
+++ b/AppCheckCore/Sources/Core/GACAppCheckLogger.m
@@ -48,7 +48,7 @@ static NSString *MessageCodeEnumToString(GACAppCheckMessageCode code) {
   return [[NSString alloc] initWithFormat:@"I-GAC%06ld", (long)code];
 }
 
-NSString *LoggerLevelEnumToString(GACAppCheckLogLevel logLevel) {
+static NSString *LoggerLevelEnumToString(GACAppCheckLogLevel logLevel) {
   switch (logLevel) {
     case GACAppCheckLogLevelFault:
       return @"Fault";

--- a/AppCheckCore/Sources/Core/GACAppCheckLogger.m
+++ b/AppCheckCore/Sources/Core/GACAppCheckLogger.m
@@ -44,11 +44,11 @@ static volatile GACAppCheckLogLevel _logLevel;
 
 #pragma mark - Helpers
 
-NSString *GACAppCheckMessageCodeEnumToString(GACAppCheckMessageCode code) {
+static NSString *MessageCodeEnumToString(GACAppCheckMessageCode code) {
   return [[NSString alloc] initWithFormat:@"I-GAC%06ld", (long)code];
 }
 
-NSString *GACAppCheckLoggerLevelEnumToString(GACAppCheckLogLevel logLevel) {
+NSString *LoggerLevelEnumToString(GACAppCheckLogLevel logLevel) {
   switch (logLevel) {
     case GACAppCheckLogLevelFault:
       return @"Fault";
@@ -78,8 +78,8 @@ void GACAppCheckLog(GACAppCheckMessageCode code, GACAppCheckLogLevel logLevel, N
   // Don't log anything in not debug builds.
 #if !NDEBUG
   if (logLevel >= GACAppCheckLogger.logLevel) {
-    NSLog(@"<%@> [AppCheckCore][%@] %@", GACAppCheckLoggerLevelEnumToString(logLevel),
-          GACAppCheckMessageCodeEnumToString(code), message);
+    NSLog(@"<%@> [AppCheckCore][%@] %@", LoggerLevelEnumToString(logLevel),
+          MessageCodeEnumToString(code), message);
   }
 #endif  // !NDEBUG
 }

--- a/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m
+++ b/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m
@@ -117,21 +117,21 @@ static NSString *const kDebugTokenUserDefaultsKey = @"GACAppCheckDebugToken";
       });
 }
 
-static NSString *LocalDebugToken() {
+static NSString *LocalDebugToken(void) {
   return StoredDebugToken() ?: GenerateAndStoreDebugToken();
 }
 
-static NSString *_Nullable StoredDebugToken() {
+static NSString *_Nullable StoredDebugToken(void) {
   return [[NSUserDefaults standardUserDefaults] stringForKey:kDebugTokenUserDefaultsKey];
 }
 
-static NSString *GenerateAndStoreDebugToken() {
+static NSString *GenerateAndStoreDebugToken(void) {
   NSString *token = [NSUUID UUID].UUIDString;
   [[NSUserDefaults standardUserDefaults] setObject:token forKey:kDebugTokenUserDefaultsKey];
   return token;
 }
 
-static NSString *_Nullable EnvironmentVariableDebugToken() {
+static NSString *_Nullable EnvironmentVariableDebugToken(void) {
   NSDictionary<NSString *, NSString *> *environment = [[NSProcessInfo processInfo] environment];
   NSString *envVariableValue = environment[kDebugTokenEnvKey];
   NSString *firebaseEnvVariableValue = environment[kFirebaseDebugTokenEnvKey];


### PR DESCRIPTION
Addresses the following warnings:
- `A function declaration without a prototype is deprecated in all versions of C`
  - See https://stackoverflow.com/questions/75943541/a-function-declaration-without-a-prototype-is-deprecated-in-all-versions-of-c for more details
  - Changed `()` to `(void)`
- `No previous prototype for function '$FunctionName'`
  - Made `GACAppCheckLogger` helper functions static since they are not accessible outside the file. Removed the, now extraneous, `GACAppCheck` prefix from the function names (see https://google.github.io/styleguide/objcguide.html#function-names).