### PR TITLE
Update AppCheckCore.podspec version to `0.1.0-alpha.9`

### DIFF
--- a/AppCheckCore.podspec
+++ b/AppCheckCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AppCheckCore'
-  s.version          = '0.1.0-alpha.8'
+  s.version          = '0.1.0-alpha.9'
   s.summary          = 'App Check Core SDK.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
This is already pushed to https://github.com/firebase/SpecsDev/blob/91b0353e1e75f535f9736c8cab72cb0e3f2c12ac/AppCheckCore/0.1.0-alpha.9/AppCheckCore.podspec -- this just checks in the latest semantic version for reference.