### PR TITLE
Upgrade to `clang-format` v17

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup check
       run: |
         brew update
-        brew install clang-format@16
+        brew install clang-format@17
         brew install mint
         mint bootstrap
 


### PR DESCRIPTION
Switched to the Homebrew `clang-format@17` formula since `clang-format@16` is no longer available.