### PR TITLE
Add failure reasons for App Attest error cases

### DIFF
--- a/AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.h
+++ b/AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.h
@@ -49,7 +49,19 @@ void GACAppCheckSetErrorToPointer(NSError *error, NSError **pointer);
 
 + (NSError *)unsupportedAttestationProvider:(NSString *)providerName;
 
+// MARK: - App Attest Errors
+
 + (NSError *)appAttestKeyIDNotFound;
+
++ (NSError *)appAttestGenerateKeyFailedWithError:(NSError *)error;
+
++ (NSError *)appAttestAttestKeyFailedWithError:(NSError *)error
+                                         keyId:(NSString *)keyId
+                                clientDataHash:(NSData *)clientDataHash;
+
++ (NSError *)appAttestGenerateAssertionFailedWithError:(NSError *)error
+                                                 keyId:(NSString *)keyId
+                                        clientDataHash:(NSData *)clientDataHash;
 
 @end
 

--- a/AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.m
+++ b/AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.m
@@ -105,6 +105,14 @@
                      underlyingError:nil];
 }
 
++ (NSError *)errorWithFailureReason:(NSString *)failureReason {
+  return [self appCheckErrorWithCode:GACAppCheckErrorCodeUnknown
+                       failureReason:failureReason
+                     underlyingError:nil];
+}
+
+#pragma mark - App Attest
+
 + (NSError *)appAttestKeyIDNotFound {
   NSString *failureReason = [NSString stringWithFormat:@"App attest key ID not found."];
   return [self appCheckErrorWithCode:GACAppCheckErrorCodeUnknown
@@ -112,10 +120,41 @@
                      underlyingError:nil];
 }
 
-+ (NSError *)errorWithFailureReason:(NSString *)failureReason {
++ (NSError *)appAttestGenerateKeyFailedWithError:(NSError *)error {
+  NSString *failureReason = @"Failed to generate a new cryptographic key for use with the App "
+                            @"Attest service (`generateKeyWithCompletionHandler:`).";
+  // TODO(#31): Add a new error code for this case (e.g., GACAppCheckAppAttestGenerateKeyFailed).
   return [self appCheckErrorWithCode:GACAppCheckErrorCodeUnknown
                        failureReason:failureReason
-                     underlyingError:nil];
+                     underlyingError:error];
+}
+
++ (NSError *)appAttestAttestKeyFailedWithError:(NSError *)error
+                                         keyId:(NSString *)keyId
+                                clientDataHash:(NSData *)clientDataHash {
+  NSString *failureReason =
+      [NSString stringWithFormat:@"Failed to attest the validity of the generated cryptographic "
+                                 @"key (`attestKey:clientDataHash:completionHandler:`); "
+                                 @"keyId.length = %lu, clientDataHash.length = %lu",
+                                 keyId.length, clientDataHash.length];
+  // TODO(#31): Add a new error code for this case (e.g., GACAppCheckAppAttestAttestKeyFailed).
+  return [self appCheckErrorWithCode:GACAppCheckErrorCodeUnknown
+                       failureReason:failureReason
+                     underlyingError:error];
+}
+
++ (NSError *)appAttestGenerateAssertionFailedWithError:(NSError *)error
+                                                 keyId:(NSString *)keyId
+                                        clientDataHash:(NSData *)clientDataHash {
+  NSString *failureReason = [NSString
+      stringWithFormat:@"Failed to create a block of data that demonstrates the legitimacy of the "
+                       @"app instance (`generateAssertion:clientDataHash:completionHandler:`); "
+                       @"keyId.length = %lu, clientDataHash.length = %lu.",
+                       keyId.length, clientDataHash.length];
+  // TODO(#31): Add error code for this case (e.g., GACAppCheckAppAttestGenerateAssertionFailed).
+  return [self appCheckErrorWithCode:GACAppCheckErrorCodeUnknown
+                       failureReason:failureReason
+                     underlyingError:error];
 }
 
 #pragma mark - Helpers

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
@@ -390,6 +390,10 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
   NSError *attestationError = [NSError errorWithDomain:@"testGetTokenWhenKeyAttestationError"
                                                   code:0
                                               userInfo:nil];
+  NSError *expectedError =
+      [GACAppCheckErrorUtil appAttestAttestKeyFailedWithError:attestationError
+                                                        keyId:existingKeyID
+                                               clientDataHash:self.randomChallengeHash];
   id attestCompletionArg = [OCMArg invokeBlockWithArgs:[NSNull null], attestationError, nil];
   OCMExpect([self.mockAppAttestService attestKey:existingKeyID
                                   clientDataHash:self.randomChallengeHash
@@ -410,7 +414,7 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
         [completionExpectation fulfill];
 
         XCTAssertNil(token);
-        XCTAssertEqualObjects(error, attestationError);
+        XCTAssertEqualObjects(error, expectedError);
       }];
 
   [self waitForExpectations:@[ self.fakeBackoffWrapper.backoffExpectation, completionExpectation ]
@@ -421,7 +425,7 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
   [self verifyAllMocks];
 
   // 9. Verify backoff error.
-  XCTAssertEqualObjects(self.fakeBackoffWrapper.operationError, attestationError);
+  XCTAssertEqualObjects(self.fakeBackoffWrapper.operationError, expectedError);
 }
 
 - (void)testGetToken_WhenUnregisteredKeyAndKeyAttestationExchangeError {
@@ -697,6 +701,10 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
       [NSError errorWithDomain:@"testGetToken_WhenKeyRegisteredAndGenerateAssertionError"
                           code:0
                       userInfo:nil];
+  NSError *expectedError =
+      [GACAppCheckErrorUtil appAttestGenerateAssertionFailedWithError:generateAssertionError
+                                                                keyId:existingKeyID
+                                                       clientDataHash:self.randomChallengeHash];
   id completionBlockArg = [OCMArg invokeBlockWithArgs:[NSNull null], generateAssertionError, nil];
   OCMExpect([self.mockAppAttestService
       generateAssertion:existingKeyID
@@ -718,7 +726,7 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
         [completionExpectation fulfill];
 
         XCTAssertNil(token);
-        XCTAssertEqualObjects(error, generateAssertionError);
+        XCTAssertEqualObjects(error, expectedError);
       }];
 
   [self waitForExpectations:@[ completionExpectation ] timeout:0.5];


### PR DESCRIPTION
This will allow developers to more granularly determine when errors occur in `GACAppAttestProvider` (when performing `generateKeyWithCompletionHandler:`, `attestKey:clientDataHash:completionHandler:` or `generateAssertion:clientDataHash:completionHandler:`), along with additional debugging information (`keyId` and `clientDataHash` lengths).

This is a port of https://github.com/firebase/firebase-ios-sdk/pull/11956 to this repo.