### PR TITLE
Forward declare `GACAppCheckToken` in `GACAppCheckTokenDelegate`

### DIFF
--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckTokenDelegate.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckTokenDelegate.h
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+@class GACAppCheckToken;
+
 NS_ASSUME_NONNULL_BEGIN
 
 NS_SWIFT_NAME(AppCheckCoreTokenDelegate)


### PR DESCRIPTION
Added a missing forward declaration for `GACAppCheckToken` in `GACAppCheckTokenDelegate` public header. This was uncovered when building internally with bazel.