### PR TITLE
Update CocoaPods to v1.14.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,6 @@ source 'https://rubygems.org'
 # gem 'cocoapods-core', git: "https://github.com/CocoaPods/Core.git", ref: "f7cf05720eab935d7d50e35224d263952176fb53"
 # gem 'xcodeproj', git: "https://github.com/CocoaPods/Xcodeproj.git", ref: "eeccae7275645753cbaf45d96fc4b23e4b8b3b9f"
 
-gem 'cocoapods', '1.12.1'
+gem 'cocoapods', '1.14.0'
 gem 'cocoapods-generate', '2.0.1'
 gem 'danger', '8.4.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,10 +3,15 @@ GEM
   specs:
     CFPropertyList (3.0.6)
       rexml
-    activesupport (7.0.7.2)
+    activesupport (7.1.1)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
@@ -14,17 +19,19 @@ GEM
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
+    base64 (0.1.1)
+    bigdecimal (3.1.4)
     claide (1.0.3)
     claide-plugins (0.9.2)
       cork
       nap
       open4 (~> 1.3)
-    cocoapods (1.12.1)
+    cocoapods (1.14.0)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.12.1)
+      cocoapods-core (= 1.14.0)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 1.6.0, < 2.0)
+      cocoapods-downloader (>= 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
       cocoapods-trunk (>= 1.6.0, < 2.0)
@@ -36,8 +43,8 @@ GEM
       molinillo (~> 0.8.0)
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
-      xcodeproj (>= 1.21.0, < 2.0)
-    cocoapods-core (1.12.1)
+      xcodeproj (>= 1.23.0, < 2.0)
+    cocoapods-core (1.14.0)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -49,7 +56,7 @@ GEM
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.5)
     cocoapods-disable-podfile-validations (0.1.1)
-    cocoapods-downloader (1.6.3)
+    cocoapods-downloader (2.0)
     cocoapods-generate (2.0.1)
       cocoapods-disable-podfile-validations (~> 0.1.1)
     cocoapods-plugins (1.0.0)
@@ -61,6 +68,7 @@ GEM
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
     cork (0.3.0)
       colored2 (~> 3.1)
     danger (8.4.5)
@@ -76,6 +84,8 @@ GEM
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (>= 1, < 4)
+    drb (2.1.1)
+      ruby2_keywords
     escape (0.0.4)
     ethon (0.16.0)
       ffi (>= 1.15.0)
@@ -104,7 +114,7 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    ffi (1.15.5)
+    ffi (1.16.3)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -119,9 +129,10 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    minitest (5.19.0)
+    minitest (5.20.0)
     molinillo (0.8.0)
     multipart-post (2.1.1)
+    mutex_m (0.1.2)
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
@@ -145,7 +156,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
-    xcodeproj (1.22.0)
+    xcodeproj (1.23.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -157,7 +168,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (= 1.12.1)
+  cocoapods (= 1.14.0)
   cocoapods-generate (= 2.0.1)
   danger (= 8.4.5)
 


### PR DESCRIPTION
Updated to CocoaPods 1.14.0 to match https://github.com/firebase/firebase-ios-sdk/pull/12008.