### PR TITLE
Replace XCTest module imports

### DIFF
--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckLoggerTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckLoggerTests.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckLogger.h"
 

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckTokenResultTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckTokenResultTests.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@import XCTest;
+#import <XCTest/XCTest.h>
 
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckToken.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckTokenResult.h"


### PR DESCRIPTION
Replaced `@import XCTest` with `#import <XCTest/XCTest.h>` for internal bazel builds without modules enabled.