### PR TITLE
Fix warning due to NSUInteger length on watchOS

### DIFF
--- a/.github/workflows/app_check_core.yml
+++ b/.github/workflows/app_check_core.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        target: [ios, tvos, macos, watchos]
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.m
+++ b/AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.m
@@ -136,7 +136,7 @@
       [NSString stringWithFormat:@"Failed to attest the validity of the generated cryptographic "
                                  @"key (`attestKey:clientDataHash:completionHandler:`); "
                                  @"keyId.length = %lu, clientDataHash.length = %lu",
-                                 keyId.length, clientDataHash.length];
+                                 (unsigned long)keyId.length, (unsigned long)clientDataHash.length];
   // TODO(#31): Add a new error code for this case (e.g., GACAppCheckAppAttestAttestKeyFailed).
   return [self appCheckErrorWithCode:GACAppCheckErrorCodeUnknown
                        failureReason:failureReason
@@ -150,7 +150,7 @@
       stringWithFormat:@"Failed to create a block of data that demonstrates the legitimacy of the "
                        @"app instance (`generateAssertion:clientDataHash:completionHandler:`); "
                        @"keyId.length = %lu, clientDataHash.length = %lu.",
-                       keyId.length, clientDataHash.length];
+                       (unsigned long)keyId.length, (unsigned long)clientDataHash.length];
   // TODO(#31): Add error code for this case (e.g., GACAppCheckAppAttestGenerateAssertionFailed).
   return [self appCheckErrorWithCode:GACAppCheckErrorCodeUnknown
                        failureReason:failureReason


### PR DESCRIPTION
- Fixed `warning: values of type 'NSUInteger' should not be used as format arguments; add an explicit cast to 'unsigned long' instead` on watchOS.
- Added `watchos` to `pod lib lint` testing matrix.

This is a port of https://github.com/firebase/firebase-ios-sdk/pull/11974.