### PR TITLE
Update CocoaPods to v1.14.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,6 @@ source 'https://rubygems.org'
 # gem 'cocoapods-core', git: "https://github.com/CocoaPods/Core.git", ref: "f7cf05720eab935d7d50e35224d263952176fb53"
 # gem 'xcodeproj', git: "https://github.com/CocoaPods/Xcodeproj.git", ref: "eeccae7275645753cbaf45d96fc4b23e4b8b3b9f"
 
-gem 'cocoapods', '1.14.0'
+gem 'cocoapods', '1.14.2'
 gem 'cocoapods-generate', '2.0.1'
 gem 'danger', '8.4.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,10 +26,10 @@ GEM
       cork
       nap
       open4 (~> 1.3)
-    cocoapods (1.14.0)
+    cocoapods (1.14.2)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.14.0)
+      cocoapods-core (= 1.14.2)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -44,7 +44,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
       xcodeproj (>= 1.23.0, < 2.0)
-    cocoapods-core (1.14.0)
+    cocoapods-core (1.14.2)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -168,7 +168,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (= 1.14.0)
+  cocoapods (= 1.14.2)
   cocoapods-generate (= 2.0.1)
   danger (= 8.4.5)
 


### PR DESCRIPTION
Updated `cocoapods` to `1.14.2` to fix a bug when attempting to publish a Pod with `pod trunk push` in certain cases (https://github.com/CocoaPods/Core/pull/759).

This matches https://github.com/firebase/firebase-ios-sdk/pull/12015.

