### PR TITLE
Update cocoapods-generate to v2.2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,5 @@ source 'https://rubygems.org'
 # gem 'xcodeproj', git: "https://github.com/CocoaPods/Xcodeproj.git", ref: "eeccae7275645753cbaf45d96fc4b23e4b8b3b9f"
 
 gem 'cocoapods', '1.14.2'
-gem 'cocoapods-generate', '2.0.1'
+gem 'cocoapods-generate', '2.2.5'
 gem 'danger', '8.4.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,10 +55,10 @@ GEM
       public_suffix (~> 4.0)
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.5)
-    cocoapods-disable-podfile-validations (0.1.1)
+    cocoapods-disable-podfile-validations (0.2.0)
     cocoapods-downloader (2.0)
-    cocoapods-generate (2.0.1)
-      cocoapods-disable-podfile-validations (~> 0.1.1)
+    cocoapods-generate (2.2.5)
+      cocoapods-disable-podfile-validations (>= 0.1.1, < 0.3.0)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.1)
@@ -169,7 +169,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (= 1.14.2)
-  cocoapods-generate (= 2.0.1)
+  cocoapods-generate (= 2.2.5)
   danger (= 8.4.5)
 
 BUNDLED WITH


### PR DESCRIPTION
Updated `cocoapods-generate` to `2.2.5`, which includes Xcode 14/15 fixes:
- https://github.com/square/cocoapods-generate/commit/63d5c28322fd8d9a787d7729c8531417cf347d8b
- https://github.com/square/cocoapods-generate/commit/a602226e509ab82266778396bfd28297be8dbf57
- https://github.com/square/cocoapods-generate/commit/52428d4d45b922e11849bcb2c4a99c89b77db3f7
- https://github.com/square/cocoapods-generate/commit/b212ea0e80f40dd83d913ff9f7346b43d3c0f36e

This matches https://github.com/firebase/firebase-ios-sdk/pull/12013.