### PR TITLE
Reset App Attest key state if `attestKey` fails

### DIFF
--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
@@ -16,6 +16,7 @@
 
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppAttestProvider.h"
 
+#import <DeviceCheck/DeviceCheck.h>
 #import <XCTest/XCTest.h>
 
 #import <OCMock/OCMock.h>
@@ -623,6 +624,76 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
   [self waitForExpectations:@[ completionExpectation ] timeout:0.5 enforceOrder:YES];
 
   // 9. Verify mocks.
+  [self verifyAllMocks];
+}
+
+- (void)testGetToken_WhenExistingKeyIsRejectedByApple_ThenAttestationIsResetAndRetriedOnce_Success {
+  // 1. Expect GACAppAttestService.isSupported.
+  [OCMExpect([self.mockAppAttestService isSupported]) andReturnValue:@(YES)];
+
+  // 2. Expect storage getAppAttestKeyID.
+  NSString *existingKeyID = @"existingKeyID";
+  OCMExpect([self.mockStorage getAppAttestKeyID])
+      .andReturn([FBLPromise resolvedWith:existingKeyID]);
+
+  // 3. Expect a stored artifact to be requested.
+  __auto_type rejectedPromise = [self rejectedPromiseWithError:[NSError errorWithDomain:self.name
+                                                                                   code:NSNotFound
+                                                                               userInfo:nil]];
+  OCMExpect([self.mockArtifactStorage getArtifactForKey:existingKeyID]).andReturn(rejectedPromise);
+
+  // 4. Expect random challenge to be requested.
+  OCMExpect([self.mockAPIService getRandomChallenge])
+      .andReturn([FBLPromise resolvedWith:self.randomChallenge]);
+
+  // 5. Expect the key to be attested with the challenge.
+  NSError *attestationError = [NSError errorWithDomain:DCErrorDomain
+                                                  code:DCErrorInvalidKey
+                                              userInfo:nil];
+  id attestCompletionArg = [OCMArg invokeBlockWithArgs:[NSNull null], attestationError, nil];
+  OCMExpect([self.mockAppAttestService attestKey:existingKeyID
+                                  clientDataHash:self.randomChallengeHash
+                               completionHandler:attestCompletionArg]);
+
+  // 6. Stored attestation to be reset.
+  [self expectAttestationReset];
+
+  // 7. Expect the App Attest key pair to be generated and attested.
+  NSString *newKeyID = @"newKeyID";
+  NSData *attestationData = [[NSUUID UUID].UUIDString dataUsingEncoding:NSUTF8StringEncoding];
+  [self expectAppAttestKeyGeneratedAndAttestedWithKeyID:newKeyID attestationData:attestationData];
+
+  // 8. Expect exchange request to be sent.
+  GACAppCheckToken *appCheckToken = [[GACAppCheckToken alloc] initWithToken:@"App Check Token"
+                                                             expirationDate:[NSDate date]];
+  NSData *artifactData = [@"attestation artifact" dataUsingEncoding:NSUTF8StringEncoding];
+  __auto_type attestKeyResponse =
+      [[GACAppAttestAttestationResponse alloc] initWithArtifact:artifactData token:appCheckToken];
+  OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData
+                                                    keyID:newKeyID
+                                                challenge:self.randomChallenge
+                                               limitedUse:NO])
+      .andReturn([FBLPromise resolvedWith:attestKeyResponse]);
+
+  // 9. Expect the artifact received from Firebase backend to be saved.
+  OCMExpect([self.mockArtifactStorage setArtifact:artifactData forKey:newKeyID])
+      .andReturn([FBLPromise resolvedWith:artifactData]);
+
+  // 10. Call get token.
+  XCTestExpectation *completionExpectation =
+      [self expectationWithDescription:@"completionExpectation"];
+  [self.provider
+      getTokenWithCompletion:^(GACAppCheckToken *_Nullable token, NSError *_Nullable error) {
+        [completionExpectation fulfill];
+
+        XCTAssertEqualObjects(token.token, appCheckToken.token);
+        XCTAssertEqualObjects(token.expirationDate, appCheckToken.expirationDate);
+        XCTAssertNil(error);
+      }];
+
+  [self waitForExpectations:@[ completionExpectation ] timeout:0.5 enforceOrder:YES];
+
+  // 11. Verify mocks.
   [self verifyAllMocks];
 }
 

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+#import "AppCheckCore/Sources/Public/AppCheckCore/GACAppAttestProvider.h"
+
 #import <XCTest/XCTest.h>
 
 #import <OCMock/OCMock.h>
 #import "FBLPromise+Testing.h"
-
-#import "AppCheckCore/Sources/Public/AppCheckCore/GACAppAttestProvider.h"
 
 #import "AppCheckCore/Sources/AppAttestProvider/API/GACAppAttestAPIService.h"
 #import "AppCheckCore/Sources/AppAttestProvider/API/GACAppAttestAttestationResponse.h"


### PR DESCRIPTION
Resets the stored key ID if [`attestKey:clientDataHash:completionHandler:`](https://developer.apple.com/documentation/devicecheck/dcappattestservice/3573911-attestkey?language=objc) fails due to [`DCErrorInvalidKey`](https://developer.apple.com/documentation/devicecheck/dcerror/dcerrorinvalidkey?language=objc). This should resolve App Check / App Attest failures after app reinstallation, device migration, or restoration of a device from a backup (see [docs](https://developer.apple.com/documentation/devicecheck/establishing_your_app_s_integrity?language=objc)).

This is a port of https://github.com/firebase/firebase-ios-sdk/pull/11986 to this repo.