### PR TITLE
[Release] Add CHANGELOG entry and update version to 10.18.1

### DIFF
--- a/AppCheckCore.podspec
+++ b/AppCheckCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AppCheckCore'
-  s.version          = '10.18.0'
+  s.version          = '10.18.1'
   s.summary          = 'App Check Core SDK.'
 
   s.description      = <<-DESC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 10.18.1
+- [changed] Added underlying `DCError` descriptions to App Attest error messages. (#47)
+
 # 10.18.0
 - Initial release.
 - Core functionality extracted from


### PR DESCRIPTION
In preparation for a 10.18.1 patch release, added a CHANGELOG entry and updated the podspec version.