### PR TITLE
Add `clientDataHash` to App Attest failure reasons

### DIFF
--- a/AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.m
+++ b/AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.m
@@ -18,6 +18,7 @@
 
 #import <DeviceCheck/DeviceCheck.h>
 
+#import <GoogleUtilities/GULAppEnvironmentUtil.h>
 #import <GoogleUtilities/GULKeychainUtils.h>
 
 #import "AppCheckCore/Sources/Core/Errors/GACAppCheckHTTPError.h"
@@ -139,8 +140,11 @@
   NSString *failureReason =
       [NSString stringWithFormat:@"Failed to attest the validity of the generated cryptographic "
                                  @"key (`attestKey:clientDataHash:completionHandler:`); "
-                                 @"keyId.length = %lu, clientDataHash.length = %lu; %@.",
-                                 (unsigned long)keyId.length, (unsigned long)clientDataHash.length,
+                                 @"keyId.length = %lu, clientDataHash = %@, systemVersion = %@; "
+                                 @"%@.",
+                                 (unsigned long)keyId.length,
+                                 [clientDataHash base64EncodedStringWithOptions:0],
+                                 [GULAppEnvironmentUtil systemVersion],
                                  [self errorDescriptionWithDeviceCheckError:error]];
   // TODO(#31): Add a new error code for this case (e.g., GACAppCheckAppAttestAttestKeyFailed).
   return [self appCheckErrorWithCode:GACAppCheckErrorCodeUnknown
@@ -154,8 +158,10 @@
   NSString *failureReason = [NSString
       stringWithFormat:@"Failed to create a block of data that demonstrates the legitimacy of the "
                        @"app instance (`generateAssertion:clientDataHash:completionHandler:`); "
-                       @"keyId.length = %lu, clientDataHash.length = %lu; %@.",
-                       (unsigned long)keyId.length, (unsigned long)clientDataHash.length,
+                       @"keyId.length = %lu, clientDataHash = %@, systemVersion = %@; %@.",
+                       (unsigned long)keyId.length,
+                       [clientDataHash base64EncodedStringWithOptions:0],
+                       [GULAppEnvironmentUtil systemVersion],
                        [self errorDescriptionWithDeviceCheckError:error]];
   // TODO(#31): Add error code for this case (e.g., GACAppCheckAppAttestGenerateAssertionFailed).
   return [self appCheckErrorWithCode:GACAppCheckErrorCodeUnknown

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
@@ -772,10 +772,14 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
       [NSError errorWithDomain:@"testGetToken_WhenKeyRegisteredAndGenerateAssertionError"
                           code:0
                       userInfo:nil];
+
+  NSMutableData *statementForAssertion = [storedArtifact mutableCopy];
+  [statementForAssertion appendData:self.randomChallenge];
+  NSData *clientDataHash = [GACAppCheckCryptoUtils sha256HashFromData:[statementForAssertion copy]];
   NSError *expectedError =
       [GACAppCheckErrorUtil appAttestGenerateAssertionFailedWithError:generateAssertionError
                                                                 keyId:existingKeyID
-                                                       clientDataHash:self.randomChallengeHash];
+                                                       clientDataHash:clientDataHash];
   id completionBlockArg = [OCMArg invokeBlockWithArgs:[NSNull null], generateAssertionError, nil];
   OCMExpect([self.mockAppAttestService
       generateAssertion:existingKeyID


### PR DESCRIPTION
- Replaced the length of the `clientDataHash` with the actual hash (as base64) in failure reason messages
- Added the OS version to the message

This provides additional debugging information for https://github.com/firebase/firebase-ios-sdk/issues/12629.