### PR TITLE
Upgrade to `clang-format` v18

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,8 +2,6 @@ name: check
 
 on:
   pull_request:
-    paths:
-    - '.github/workflows/check.yml'
   push:
     branches: main
 
@@ -36,7 +34,7 @@ jobs:
     - name: Setup check
       run: |
         brew update
-        brew install clang-format@17
+        brew install clang-format@18
         brew install mint
         mint bootstrap
 


### PR DESCRIPTION
- Switched to the Homebrew `clang-format@18` formula since `clang-format@17` is no longer available
- Updated `check` workflow to run on all pull requests (this [failure](https://github.com/google/app-check/actions/runs/8473511935/job/23217991076) wasn't caught until after merging)