### PR TITLE
[Infra] Remove check setup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,10 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v3
-      with:
-        python-version: 3.6
-
     - name: Cache Mint packages
       uses: actions/cache@v3
       with:


### PR DESCRIPTION
`check` fails due to missing python version on runner. It doesn't appear that the python setup is needed though.