### PR TITLE
[Release] Update AppCheckCore.podspec for compatibility with Firebase 11

### DIFF
--- a/AppCheckCore.podspec
+++ b/AppCheckCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AppCheckCore'
-  s.version          = '10.19.1'
+  s.version          = '11.0.0'
   s.summary          = 'App Check Core SDK.'
 
   s.description      = <<-DESC
@@ -44,8 +44,8 @@ Pod::Spec.new do |s|
   s.tvos.weak_framework = 'DeviceCheck'
 
   s.dependency 'PromisesObjC', '~> 2.3'
-  s.dependency 'GoogleUtilities/Environment', '~> 7.13'
-  s.dependency 'GoogleUtilities/UserDefaults', '~> 7.13'
+  s.dependency 'GoogleUtilities/Environment', '~> 8.0'
+  s.dependency 'GoogleUtilities/UserDefaults', '~> 8.0'
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,9 @@ let package = Package(
     ),
     .package(
       url: "https://github.com/google/GoogleUtilities.git",
-      "7.11.5" ..< "8.0.0"
+      branch: "release-8.0"
+      // TODO: Enable after GULs v8 publishes.
+      // "8.0.0" ..< "9.0.0"
     ),
     .package(
       url: "https://github.com/erikdoe/ocmock.git",


### PR DESCRIPTION
AppCheckCore's dependency on GoogleUtilities will require a major version update to be compatible with Firebase 11.