### PR TITLE
[v11] Migrate to GoogleUtilities v8

### DIFF
--- a/.github/workflows/app_check_core.yml
+++ b/.github/workflows/app_check_core.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Build and test
       run: |
         scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb AppCheckCore.podspec \
-          --platforms=${{ matrix.target }}
+          --platforms=${{ matrix.target }} --verbose
 
   catalyst:
     runs-on: macos-latest

--- a/.github/workflows/app_check_core.yml
+++ b/.github/workflows/app_check_core.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Build and test
       run: |
         scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb AppCheckCore.podspec \
-          --platforms=${{ matrix.target }} --verbose
+          --platforms=${{ matrix.target }}
 
   catalyst:
     runs-on: macos-latest

--- a/AppCheckCore/Sources/AppAttestProvider/API/GACAppAttestAPIService.m
+++ b/AppCheckCore/Sources/AppAttestProvider/API/GACAppAttestAPIService.m
@@ -24,9 +24,8 @@
 
 #import "AppCheckCore/Sources/AppAttestProvider/API/GACAppAttestAttestationResponse.h"
 #import "AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.h"
+#import "AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.h"
 #import "AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.h"
-
-#import <GoogleUtilities/GULURLSessionDataResponse.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -77,13 +76,13 @@ static NSString *const kHTTPMethodPost = @"POST";
                           challenge:challenge
                           assertion:assertion
                          limitedUse:limitedUse]
-      .then(^FBLPromise<GULURLSessionDataResponse *> *(NSData *HTTPBody) {
+      .then(^FBLPromise<GACURLSessionDataResponse *> *(NSData *HTTPBody) {
         return [self.APIService sendRequestWithURL:URL
                                         HTTPMethod:kHTTPMethodPost
                                               body:HTTPBody
                                  additionalHeaders:@{kContentTypeKey : kJSONContentType}];
       })
-      .then(^id _Nullable(GULURLSessionDataResponse *_Nullable response) {
+      .then(^id _Nullable(GACURLSessionDataResponse *_Nullable response) {
         return [self.APIService appCheckTokenWithAPIResponse:response];
       });
 }
@@ -100,14 +99,14 @@ static NSString *const kHTTPMethodPost = @"POST";
                                                                   body:nil
                                                      additionalHeaders:nil];
                           }]
-      .then(^id _Nullable(GULURLSessionDataResponse *_Nullable response) {
+      .then(^id _Nullable(GACURLSessionDataResponse *_Nullable response) {
         return [self randomChallengeWithAPIResponse:response];
       });
 }
 
 #pragma mark - Challenge response parsing
 
-- (FBLPromise<NSData *> *)randomChallengeWithAPIResponse:(GULURLSessionDataResponse *)response {
+- (FBLPromise<NSData *> *)randomChallengeWithAPIResponse:(GACURLSessionDataResponse *)response {
   return [FBLPromise onQueue:[self backgroundQueue]
                           do:^id _Nullable {
                             NSError *error;
@@ -160,14 +159,14 @@ static NSString *const kHTTPMethodPost = @"POST";
                                  keyID:keyID
                              challenge:challenge
                             limitedUse:limitedUse]
-      .then(^FBLPromise<GULURLSessionDataResponse *> *(NSData *HTTPBody) {
+      .then(^FBLPromise<GACURLSessionDataResponse *> *(NSData *HTTPBody) {
         return [self.APIService sendRequestWithURL:URL
                                         HTTPMethod:kHTTPMethodPost
                                               body:HTTPBody
                                  additionalHeaders:@{kContentTypeKey : kJSONContentType}];
       })
       .thenOn(
-          [self backgroundQueue], ^id _Nullable(GULURLSessionDataResponse *_Nullable URLResponse) {
+          [self backgroundQueue], ^id _Nullable(GACURLSessionDataResponse *_Nullable URLResponse) {
             NSError *error;
 
             __auto_type response =

--- a/AppCheckCore/Sources/AppAttestProvider/Storage/GACAppAttestArtifactStorage.m
+++ b/AppCheckCore/Sources/AppAttestProvider/Storage/GACAppAttestArtifactStorage.m
@@ -88,16 +88,17 @@ static NSString *const kKeychainService = @"com.firebase.app_check.app_attest_ar
       return [GACAppCheckErrorUtil keychainErrorWithError:error];
     });
   } else {
-    return [FBLPromise wrapErrorCompletion:^(FBLPromiseErrorCompletion  _Nonnull handler) {
-      [self.keychainStorage removeObjectForKey:[self artifactKey]
-                                   accessGroup:self.accessGroup
-                             completionHandler:handler];
-        }].then(^id _Nullable(id _Nullable __unused _) {
-              return nil;
-            })
-            .recover(^NSError *(NSError *error) {
-              return [GACAppCheckErrorUtil keychainErrorWithError:error];
-            });
+    return [FBLPromise wrapErrorCompletion:^(FBLPromiseErrorCompletion _Nonnull handler) {
+             [self.keychainStorage removeObjectForKey:[self artifactKey]
+                                          accessGroup:self.accessGroup
+                                    completionHandler:handler];
+           }]
+        .then(^id _Nullable(id _Nullable __unused _) {
+          return nil;
+        })
+        .recover(^NSError *(NSError *error) {
+          return [GACAppCheckErrorUtil keychainErrorWithError:error];
+        });
   }
 }
 

--- a/AppCheckCore/Sources/AppAttestProvider/Storage/GACAppAttestArtifactStorage.m
+++ b/AppCheckCore/Sources/AppAttestProvider/Storage/GACAppAttestArtifactStorage.m
@@ -88,13 +88,11 @@ static NSString *const kKeychainService = @"com.firebase.app_check.app_attest_ar
       return [GACAppCheckErrorUtil keychainErrorWithError:error];
     });
   } else {
-    return
-        [FBLPromise wrapBoolOrErrorCompletion:^(FBLPromiseBoolOrErrorCompletion _Nonnull handler) {
-          [self.keychainStorage removeObjectForKey:[self artifactKey]
-                                       accessGroup:self.accessGroup
-                                 completionHandler:handler];
-        }]
-            .then(^id _Nullable(NSNumber *__unused removeResult) {
+    return [FBLPromise wrapErrorCompletion:^(FBLPromiseErrorCompletion  _Nonnull handler) {
+      [self.keychainStorage removeObjectForKey:[self artifactKey]
+                                   accessGroup:self.accessGroup
+                             completionHandler:handler];
+        }].then(^id _Nullable(id _Nullable __unused _) {
               return nil;
             })
             .recover(^NSError *(NSError *error) {

--- a/AppCheckCore/Sources/AppAttestProvider/Storage/GACAppAttestArtifactStorage.m
+++ b/AppCheckCore/Sources/AppAttestProvider/Storage/GACAppAttestArtifactStorage.m
@@ -61,12 +61,13 @@ static NSString *const kKeychainService = @"com.firebase.app_check.app_attest_ar
 }
 
 - (FBLPromise<NSData *> *)getArtifactForKey:(NSString *)keyID {
-  return [FBLPromise wrapObjectOrErrorCompletion:^(FBLPromiseObjectOrErrorCompletion  _Nonnull handler) {
-    [self.keychainStorage getObjectForKey:[self artifactKey]
-                              objectClass:[GACAppAttestStoredArtifact class]
-                              accessGroup:self.accessGroup
-                        completionHandler:handler];
-  }]
+  return [FBLPromise
+             wrapObjectOrErrorCompletion:^(FBLPromiseObjectOrErrorCompletion _Nonnull handler) {
+               [self.keychainStorage getObjectForKey:[self artifactKey]
+                                         objectClass:[GACAppAttestStoredArtifact class]
+                                         accessGroup:self.accessGroup
+                                   completionHandler:handler];
+             }]
       .then(^NSData *(id<NSSecureCoding> storedArtifact) {
         GACAppAttestStoredArtifact *artifact = (GACAppAttestStoredArtifact *)storedArtifact;
         if ([artifact isKindOfClass:[GACAppAttestStoredArtifact class]] &&
@@ -87,15 +88,18 @@ static NSString *const kKeychainService = @"com.firebase.app_check.app_attest_ar
       return [GACAppCheckErrorUtil keychainErrorWithError:error];
     });
   } else {
-    return [FBLPromise wrapBoolOrErrorCompletion:^(FBLPromiseBoolOrErrorCompletion  _Nonnull handler) {
-      [self.keychainStorage removeObjectForKey:[self artifactKey] accessGroup:self.accessGroup completionHandler:handler];
-    }]
-        .then(^id _Nullable(NSNumber *__unused removeResult) {
-          return nil;
-        })
-        .recover(^NSError *(NSError *error) {
-          return [GACAppCheckErrorUtil keychainErrorWithError:error];
-        });
+    return
+        [FBLPromise wrapBoolOrErrorCompletion:^(FBLPromiseBoolOrErrorCompletion _Nonnull handler) {
+          [self.keychainStorage removeObjectForKey:[self artifactKey]
+                                       accessGroup:self.accessGroup
+                                 completionHandler:handler];
+        }]
+            .then(^id _Nullable(NSNumber *__unused removeResult) {
+              return nil;
+            })
+            .recover(^NSError *(NSError *error) {
+              return [GACAppCheckErrorUtil keychainErrorWithError:error];
+            });
   }
 }
 
@@ -105,12 +109,14 @@ static NSString *const kKeychainService = @"com.firebase.app_check.app_attest_ar
                                  forKey:(nonnull NSString *)keyID {
   GACAppAttestStoredArtifact *storedArtifact =
       [[GACAppAttestStoredArtifact alloc] initWithKeyID:keyID artifact:artifact];
-  return [FBLPromise wrapObjectOrErrorCompletion:^(FBLPromiseObjectOrErrorCompletion  _Nonnull handler) {
-    [self.keychainStorage setObject:storedArtifact
-                             forKey:[self artifactKey]
-                        accessGroup:self.accessGroup
-                  completionHandler:handler];
-  }].then(^id _Nullable(id<NSSecureCoding> _Nullable value) {
+  return
+      [FBLPromise wrapObjectOrErrorCompletion:^(
+                      FBLPromiseObjectOrErrorCompletion _Nonnull handler) {
+        [self.keychainStorage setObject:storedArtifact
+                                 forKey:[self artifactKey]
+                            accessGroup:self.accessGroup
+                      completionHandler:handler];
+      }].then(^id _Nullable(id<NSSecureCoding> _Nullable value) {
         return artifact;
       });
 }

--- a/AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.h
+++ b/AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.h
@@ -19,7 +19,7 @@
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppAttestProvider.h"
 
 @class FBLPromise<Result>;
-@class GULURLSessionDataResponse;
+@class GACURLSessionDataResponse;
 @class GACAppCheckToken;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -28,14 +28,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, readonly) NSString *baseURL;
 
-- (FBLPromise<GULURLSessionDataResponse *> *)
+- (FBLPromise<GACURLSessionDataResponse *> *)
     sendRequestWithURL:(NSURL *)requestURL
             HTTPMethod:(NSString *)HTTPMethod
                   body:(nullable NSData *)body
      additionalHeaders:(nullable NSDictionary<NSString *, NSString *> *)additionalHeaders;
 
 - (FBLPromise<GACAppCheckToken *> *)appCheckTokenWithAPIResponse:
-    (GULURLSessionDataResponse *)response;
+    (GACURLSessionDataResponse *)response;
 
 @end
 

--- a/AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.m
+++ b/AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.m
@@ -22,13 +22,12 @@
 #endif
 
 #import "AppCheckCore/Sources/Core/APIService/GACAppCheckToken+APIResponse.h"
+#import "AppCheckCore/Sources/Core/APIService/NSURLSession+GACPromises.h"
+#import "AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.h"
 #import "AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 #import "AppCheckCore/Sources/Core/GACAppCheckLogger+Internal.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckErrors.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckLogger.h"
-
-#import <GoogleUtilities/GULURLSessionDataResponse.h>
-#import <GoogleUtilities/NSURLSession+GULPromises.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -64,7 +63,7 @@ static NSString *const kDefaultBaseURL = @"https://firebaseappcheck.googleapis.c
   return self;
 }
 
-- (FBLPromise<GULURLSessionDataResponse *> *)
+- (FBLPromise<GACURLSessionDataResponse *> *)
     sendRequestWithURL:(NSURL *)requestURL
             HTTPMethod:(NSString *)HTTPMethod
                   body:(nullable NSData *)body
@@ -76,7 +75,7 @@ static NSString *const kDefaultBaseURL = @"https://firebaseappcheck.googleapis.c
       .then(^id _Nullable(NSURLRequest *_Nullable request) {
         return [self sendURLRequest:request];
       })
-      .then(^id _Nullable(GULURLSessionDataResponse *_Nullable response) {
+      .then(^id _Nullable(GACURLSessionDataResponse *_Nullable response) {
         return [self validateHTTPResponseStatusCode:response];
       });
 }
@@ -114,19 +113,19 @@ static NSString *const kDefaultBaseURL = @"https://firebaseappcheck.googleapis.c
            }];
 }
 
-- (FBLPromise<GULURLSessionDataResponse *> *)sendURLRequest:(NSURLRequest *)request {
-  return [self.URLSession gul_dataTaskPromiseWithRequest:request]
+- (FBLPromise<GACURLSessionDataResponse *> *)sendURLRequest:(NSURLRequest *)request {
+  return [self.URLSession gac_dataTaskPromiseWithRequest:request]
       .recover(^id(NSError *networkError) {
         // Wrap raw network error into App Check domain error.
         return [GACAppCheckErrorUtil APIErrorWithNetworkError:networkError];
       })
-      .then(^id _Nullable(GULURLSessionDataResponse *response) {
+      .then(^id _Nullable(GACURLSessionDataResponse *response) {
         return [self validateHTTPResponseStatusCode:response];
       });
 }
 
-- (FBLPromise<GULURLSessionDataResponse *> *)validateHTTPResponseStatusCode:
-    (GULURLSessionDataResponse *)response {
+- (FBLPromise<GACURLSessionDataResponse *> *)validateHTTPResponseStatusCode:
+    (GACURLSessionDataResponse *)response {
   NSInteger statusCode = response.HTTPResponse.statusCode;
   return [FBLPromise do:^id _Nullable {
     if (statusCode < 200 || statusCode >= 300) {
@@ -143,7 +142,7 @@ static NSString *const kDefaultBaseURL = @"https://firebaseappcheck.googleapis.c
 }
 
 - (FBLPromise<GACAppCheckToken *> *)appCheckTokenWithAPIResponse:
-    (GULURLSessionDataResponse *)response {
+    (GACURLSessionDataResponse *)response {
   return [FBLPromise onQueue:[self defaultQueue]
                           do:^id _Nullable {
                             NSError *error;

--- a/AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.m
+++ b/AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.m
@@ -22,8 +22,8 @@
 #endif
 
 #import "AppCheckCore/Sources/Core/APIService/GACAppCheckToken+APIResponse.h"
-#import "AppCheckCore/Sources/Core/APIService/NSURLSession+GACPromises.h"
 #import "AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.h"
+#import "AppCheckCore/Sources/Core/APIService/NSURLSession+GACPromises.h"
 #import "AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 #import "AppCheckCore/Sources/Core/GACAppCheckLogger+Internal.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckErrors.h"

--- a/AppCheckCore/Sources/Core/APIService/GACAppCheckToken+APIResponse.m
+++ b/AppCheckCore/Sources/Core/APIService/GACAppCheckToken+APIResponse.m
@@ -24,8 +24,6 @@
 
 #import "AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 
-#import <GoogleUtilities/GULURLSessionDataResponse.h>
-
 static NSString *const kResponseFieldToken = @"token";
 static NSString *const kResponseFieldTTL = @"ttl";
 

--- a/AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.h
+++ b/AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** The class represents HTTP response received from `NSURLSession`. */
+@interface GACURLSessionDataResponse : NSObject
+
+@property(nonatomic, readonly) NSHTTPURLResponse *HTTPResponse;
+@property(nonatomic, nullable, readonly) NSData *HTTPBody;
+
+- (instancetype)initWithResponse:(NSHTTPURLResponse *)response HTTPBody:(nullable NSData *)body;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.h
+++ b/AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.h
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 #import <Foundation/Foundation.h>
 

--- a/AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.m
+++ b/AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.m
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.h"
+
+@implementation GACURLSessionDataResponse
+
+- (instancetype)initWithResponse:(NSHTTPURLResponse *)response HTTPBody:(NSData *)body {
+  self = [super init];
+  if (self) {
+    _HTTPResponse = response;
+    _HTTPBody = body;
+  }
+  return self;
+}
+
+@end

--- a/AppCheckCore/Sources/Core/APIService/NSURLSession+GACPromises.h
+++ b/AppCheckCore/Sources/Core/APIService/NSURLSession+GACPromises.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,23 @@
  * limitations under the License.
  */
 
-#import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckToken.h"
+#import <Foundation/Foundation.h>
 
-@class FBLPromise<Result>;
+@class FBLPromise<Value>;
 @class GACURLSessionDataResponse;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface GACAppCheckToken (APIResponse)
+/** Promise based API for `NSURLSession`. */
+@interface NSURLSession (GACPromises)
 
-- (nullable instancetype)initWithTokenExchangeResponse:(NSData *)response
-                                           requestDate:(NSDate *)requestDate
-                                                 error:(NSError **)outError;
-
-- (nullable instancetype)initWithResponseDict:(NSDictionary<NSString *, id> *)responseDict
-                                  requestDate:(NSDate *)requestDate
-                                        error:(NSError **)outError;
+/** Creates a promise wrapping `-[NSURLSession dataTaskWithRequest:completionHandler:]` method.
+ * @param URLRequest The request to create a data task with.
+ * @return A promise that is fulfilled when an HTTP response is received (with any response code),
+ * or is rejected with the error passed to the task completion.
+ */
+- (FBLPromise<GACURLSessionDataResponse *> *)gac_dataTaskPromiseWithRequest:
+    (NSURLRequest *)URLRequest;
 
 @end
 

--- a/AppCheckCore/Sources/Core/APIService/NSURLSession+GACPromises.m
+++ b/AppCheckCore/Sources/Core/APIService/NSURLSession+GACPromises.m
@@ -24,7 +24,7 @@
 
 #import "AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.h"
 
-@implementation NSURLSession (GULPromises)
+@implementation NSURLSession (GACPromises)
 
 - (FBLPromise<GACURLSessionDataResponse *> *)gac_dataTaskPromiseWithRequest:
     (NSURLRequest *)URLRequest {

--- a/AppCheckCore/Sources/Core/APIService/NSURLSession+GACPromises.m
+++ b/AppCheckCore/Sources/Core/APIService/NSURLSession+GACPromises.m
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "AppCheckCore/Sources/Core/APIService/NSURLSession+GACPromises.h"
+
+#if __has_include(<FBLPromises/FBLPromises.h>)
+#import <FBLPromises/FBLPromises.h>
+#else
+#import "FBLPromises.h"
+#endif
+
+#import "AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.h"
+
+@implementation NSURLSession (GULPromises)
+
+- (FBLPromise<GACURLSessionDataResponse *> *)gac_dataTaskPromiseWithRequest:
+    (NSURLRequest *)URLRequest {
+  return [FBLPromise async:^(FBLPromiseFulfillBlock fulfill, FBLPromiseRejectBlock reject) {
+    [[self dataTaskWithRequest:URLRequest
+             completionHandler:^(NSData *_Nullable data, NSURLResponse *_Nullable response,
+                                 NSError *_Nullable error) {
+               if (error) {
+                 reject(error);
+               } else {
+                 fulfill([[GACURLSessionDataResponse alloc]
+                     initWithResponse:(NSHTTPURLResponse *)response
+                             HTTPBody:data]);
+               }
+             }] resume];
+  }];
+}
+
+@end

--- a/AppCheckCore/Sources/Core/Storage/GACAppCheckStorage.m
+++ b/AppCheckCore/Sources/Core/Storage/GACAppCheckStorage.m
@@ -86,12 +86,12 @@ static NSString *const kKeychainService = @"com.google.app_check_core.token_stor
     });
   } else {
     return
-        [FBLPromise wrapBoolOrErrorCompletion:^(FBLPromiseBoolOrErrorCompletion _Nonnull handler) {
+        [FBLPromise wrapErrorCompletion:^(FBLPromiseErrorCompletion _Nonnull handler) {
           [self.keychainStorage removeObjectForKey:[self tokenKey]
                                        accessGroup:self.accessGroup
                                  completionHandler:handler];
         }]
-            .then(^id _Nullable(NSNumber *__unused removeResult) {
+            .then(^id _Nullable(id _Nullable __unused _) {
               return token;
             })
             .recover(^NSError *(NSError *error) {

--- a/AppCheckCore/Sources/Core/Storage/GACAppCheckStorage.m
+++ b/AppCheckCore/Sources/Core/Storage/GACAppCheckStorage.m
@@ -60,12 +60,14 @@ static NSString *const kKeychainService = @"com.google.app_check_core.token_stor
 }
 
 - (FBLPromise<GACAppCheckToken *> *)getToken {
-  return [FBLPromise wrapObjectOrErrorCompletion:^(FBLPromiseObjectOrErrorCompletion  _Nonnull handler) {
-    [self.keychainStorage getObjectForKey:[self tokenKey]
-                            	objectClass:[GACAppCheckStoredToken class]
-                              accessGroup:self.accessGroup
-                        completionHandler:handler];
-  }].then(^GACAppCheckToken *(id<NSSecureCoding> storedToken) {
+  return [FBLPromise
+             wrapObjectOrErrorCompletion:^(FBLPromiseObjectOrErrorCompletion _Nonnull handler) {
+               [self.keychainStorage getObjectForKey:[self tokenKey]
+                                         objectClass:[GACAppCheckStoredToken class]
+                                         accessGroup:self.accessGroup
+                                   completionHandler:handler];
+             }]
+      .then(^GACAppCheckToken *(id<NSSecureCoding> storedToken) {
         if ([(NSObject *)storedToken isKindOfClass:[GACAppCheckStoredToken class]]) {
           return [(GACAppCheckStoredToken *)storedToken appCheckToken];
         } else {
@@ -83,15 +85,18 @@ static NSString *const kKeychainService = @"com.google.app_check_core.token_stor
       return [GACAppCheckErrorUtil keychainErrorWithError:error];
     });
   } else {
-    return [FBLPromise wrapBoolOrErrorCompletion:^(FBLPromiseBoolOrErrorCompletion  _Nonnull handler) {
-      [self.keychainStorage removeObjectForKey:[self tokenKey] accessGroup:self.accessGroup completionHandler:handler];
-    }]
-      .then(^id _Nullable(NSNumber *__unused removeResult) {
-        return token;
-      })
-      .recover(^NSError *(NSError *error) {
-        return [GACAppCheckErrorUtil keychainErrorWithError:error];
-      });
+    return
+        [FBLPromise wrapBoolOrErrorCompletion:^(FBLPromiseBoolOrErrorCompletion _Nonnull handler) {
+          [self.keychainStorage removeObjectForKey:[self tokenKey]
+                                       accessGroup:self.accessGroup
+                                 completionHandler:handler];
+        }]
+            .then(^id _Nullable(NSNumber *__unused removeResult) {
+              return token;
+            })
+            .recover(^NSError *(NSError *error) {
+              return [GACAppCheckErrorUtil keychainErrorWithError:error];
+            });
   }
 }
 
@@ -100,14 +105,16 @@ static NSString *const kKeychainService = @"com.google.app_check_core.token_stor
 - (FBLPromise<NSNull *> *)storeToken:(nullable GACAppCheckToken *)token {
   GACAppCheckStoredToken *storedToken = [[GACAppCheckStoredToken alloc] init];
   [storedToken updateWithToken:token];
-  return [FBLPromise wrapObjectOrErrorCompletion:^(FBLPromiseObjectOrErrorCompletion  _Nonnull handler) {
-    [self.keychainStorage setObject:storedToken
-                             forKey:[self tokenKey]
-                        accessGroup:self.accessGroup completionHandler:handler];
-  }]
-    .then(^id _Nullable(id<NSSecureCoding> _Nullable value) {
-      return token;
-    });
+  return
+      [FBLPromise wrapObjectOrErrorCompletion:^(
+                      FBLPromiseObjectOrErrorCompletion _Nonnull handler) {
+        [self.keychainStorage setObject:storedToken
+                                 forKey:[self tokenKey]
+                            accessGroup:self.accessGroup
+                      completionHandler:handler];
+      }].then(^id _Nullable(id<NSSecureCoding> _Nullable value) {
+        return token;
+      });
 }
 
 @end

--- a/AppCheckCore/Sources/Core/Storage/GACAppCheckStorage.m
+++ b/AppCheckCore/Sources/Core/Storage/GACAppCheckStorage.m
@@ -85,18 +85,17 @@ static NSString *const kKeychainService = @"com.google.app_check_core.token_stor
       return [GACAppCheckErrorUtil keychainErrorWithError:error];
     });
   } else {
-    return
-        [FBLPromise wrapErrorCompletion:^(FBLPromiseErrorCompletion _Nonnull handler) {
-          [self.keychainStorage removeObjectForKey:[self tokenKey]
-                                       accessGroup:self.accessGroup
-                                 completionHandler:handler];
-        }]
-            .then(^id _Nullable(id _Nullable __unused _) {
-              return token;
-            })
-            .recover(^NSError *(NSError *error) {
-              return [GACAppCheckErrorUtil keychainErrorWithError:error];
-            });
+    return [FBLPromise wrapErrorCompletion:^(FBLPromiseErrorCompletion _Nonnull handler) {
+             [self.keychainStorage removeObjectForKey:[self tokenKey]
+                                          accessGroup:self.accessGroup
+                                    completionHandler:handler];
+           }]
+        .then(^id _Nullable(id _Nullable __unused _) {
+          return token;
+        })
+        .recover(^NSError *(NSError *error) {
+          return [GACAppCheckErrorUtil keychainErrorWithError:error];
+        });
   }
 }
 

--- a/AppCheckCore/Sources/DebugProvider/API/GACAppCheckDebugProviderAPIService.m
+++ b/AppCheckCore/Sources/DebugProvider/API/GACAppCheckDebugProviderAPIService.m
@@ -22,9 +22,6 @@
 #import "FBLPromises.h"
 #endif
 
-#import <GoogleUtilities/GULURLSessionDataResponse.h>
-#import <GoogleUtilities/NSURLSession+GULPromises.h>
-
 #import "AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.h"
 #import "AppCheckCore/Sources/Core/APIService/GACAppCheckToken+APIResponse.h"
 
@@ -67,13 +64,13 @@ static NSString *const kLimitedUseField = @"limited_use";
   NSURL *URL = [NSURL URLWithString:URLString];
 
   return [self HTTPBodyWithDebugToken:debugToken limitedUse:limitedUse]
-      .then(^FBLPromise<GULURLSessionDataResponse *> *(NSData *HTTPBody) {
+      .then(^FBLPromise<GACURLSessionDataResponse *> *(NSData *HTTPBody) {
         return [self.APIService sendRequestWithURL:URL
                                         HTTPMethod:@"POST"
                                               body:HTTPBody
                                  additionalHeaders:@{kContentTypeKey : kJSONContentType}];
       })
-      .then(^id _Nullable(GULURLSessionDataResponse *_Nullable response) {
+      .then(^id _Nullable(GACURLSessionDataResponse *_Nullable response) {
         return [self.APIService appCheckTokenWithAPIResponse:response];
       });
 }

--- a/AppCheckCore/Sources/DeviceCheckProvider/API/GACDeviceCheckAPIService.m
+++ b/AppCheckCore/Sources/DeviceCheckProvider/API/GACDeviceCheckAPIService.m
@@ -22,8 +22,6 @@
 #import "FBLPromises.h"
 #endif
 
-#import <GoogleUtilities/GULURLSessionDataResponse.h>
-
 #import "AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.h"
 #import "AppCheckCore/Sources/Core/APIService/GACAppCheckToken+APIResponse.h"
 
@@ -66,13 +64,13 @@ static NSString *const kLimitedUseField = @"limited_use";
   NSURL *URL = [NSURL URLWithString:URLString];
 
   return [self HTTPBodyWithDeviceToken:deviceToken limitedUse:limitedUse]
-      .then(^FBLPromise<GULURLSessionDataResponse *> *(NSData *HTTPBody) {
+      .then(^FBLPromise<GACURLSessionDataResponse *> *(NSData *HTTPBody) {
         return [self.APIService sendRequestWithURL:URL
                                         HTTPMethod:@"POST"
                                               body:HTTPBody
                                  additionalHeaders:@{kContentTypeKey : kJSONContentType}];
       })
-      .then(^id _Nullable(GULURLSessionDataResponse *_Nullable response) {
+      .then(^id _Nullable(GACURLSessionDataResponse *_Nullable response) {
         return [self.APIService appCheckTokenWithAPIResponse:response];
       });
 }

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestAPIServiceTests.m
@@ -19,11 +19,10 @@
 #import <OCMock/OCMock.h>
 #import "FBLPromise+Testing.h"
 
-#import <GoogleUtilities/GULURLSessionDataResponse.h>
-
 #import "AppCheckCore/Sources/AppAttestProvider/API/GACAppAttestAPIService.h"
 #import "AppCheckCore/Sources/AppAttestProvider/API/GACAppAttestAttestationResponse.h"
 #import "AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.h"
+#import "AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.h"
 #import "AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 #import "AppCheckCore/Sources/Core/Errors/GACAppCheckHTTPError.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckErrors.h"
@@ -69,7 +68,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
 - (void)testGetRandomChallengeWhenAPIResponseValid {
   // 1. Prepare API response.
   NSData *responseBody = [GACFixtureLoader loadFixtureNamed:@"AppAttestResponseSuccess.json"];
-  GULURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
+  GACURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
                                                              responseBody:responseBody];
   // 2. Stub API Service Request to return prepared API response.
   [self stubMockAPIServiceRequestForChallengeRequestWithResponse:validAPIResponse];
@@ -94,7 +93,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   // 1. Prepare API response.
   NSString *responseBodyString = @"Generate challenge failed with invalid format.";
   NSData *responseBody = [responseBodyString dataUsingEncoding:NSUTF8StringEncoding];
-  GULURLSessionDataResponse *invalidAPIResponse = [self APIResponseWithCode:300
+  GACURLSessionDataResponse *invalidAPIResponse = [self APIResponseWithCode:300
                                                                responseBody:responseBody];
   GACAppCheckHTTPError *APIError =
       [GACAppCheckErrorUtil APIErrorWithHTTPResponse:invalidAPIResponse.HTTPResponse
@@ -124,7 +123,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
 - (void)testGetRandomChallengeWhenAPIResponseEmpty {
   // 1. Prepare API response.
   NSData *responseBody = [NSData data];
-  GULURLSessionDataResponse *emptyAPIResponse = [self APIResponseWithCode:200
+  GACURLSessionDataResponse *emptyAPIResponse = [self APIResponseWithCode:200
                                                              responseBody:responseBody];
   // 2. Stub API Service Request to return prepared API response.
   [self stubMockAPIServiceRequestForChallengeRequestWithResponse:emptyAPIResponse];
@@ -147,7 +146,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   // 1. Prepare API response.
   NSString *responseBodyString = @"Generate challenge failed with invalid format.";
   NSData *responseBody = [responseBodyString dataUsingEncoding:NSUTF8StringEncoding];
-  GULURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
+  GACURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
                                                              responseBody:responseBody];
   // 2. Stub API Service Request to return prepared API response.
   [self stubMockAPIServiceRequestForChallengeRequestWithResponse:validAPIResponse];
@@ -175,7 +174,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
                               missingField:(NSString *)fieldName {
   // 1. Prepare API response.
   NSData *missingFieldBody = [GACFixtureLoader loadFixtureNamed:fixtureName];
-  GULURLSessionDataResponse *incompleteAPIResponse = [self APIResponseWithCode:200
+  GACURLSessionDataResponse *incompleteAPIResponse = [self APIResponseWithCode:200
                                                                   responseBody:missingFieldBody];
   // 2. Stub API Service Request to return prepared API response.
   [self stubMockAPIServiceRequestForChallengeRequestWithResponse:incompleteAPIResponse];
@@ -217,7 +216,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   // 1. Prepare response.
   NSData *responseBody =
       [GACFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
-  GULURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
+  GACURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
                                                              responseBody:responseBody];
 
   // 2. Stub API Service
@@ -261,7 +260,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   // 1. Prepare response.
   NSData *responseBody =
       [GACFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
-  GULURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
+  GACURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
                                                              responseBody:responseBody];
 
   // 2. Stub API Service
@@ -297,7 +296,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   // 1. Prepare response.
   NSData *responseBody =
       [GACFixtureLoader loadFixtureNamed:@"DeviceCheckResponseMissingToken.json"];
-  GULURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
+  GACURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
                                                              responseBody:responseBody];
 
   // 2. Stub API Service
@@ -344,7 +343,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   // 1. Prepare response.
   NSData *responseBody =
       [GACFixtureLoader loadFixtureNamed:@"AppAttestAttestationResponseSuccess.json"];
-  GULURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
+  GACURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
                                                              responseBody:responseBody];
 
   // 2. Stub API Service
@@ -419,7 +418,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   // 1. Prepare unexpected response.
   NSData *responseBody =
       [GACFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
-  GULURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
+  GACURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
                                                              responseBody:responseBody];
 
   // 2. Stub API Service
@@ -449,12 +448,12 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
 
 #pragma mark - Helpers
 
-- (GULURLSessionDataResponse *)APIResponseWithCode:(NSInteger)code
+- (GACURLSessionDataResponse *)APIResponseWithCode:(NSInteger)code
                                       responseBody:(NSData *)responseBody {
   XCTAssertNotNil(responseBody);
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:code];
-  GULURLSessionDataResponse *APIResponse =
-      [[GULURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
+  GACURLSessionDataResponse *APIResponse =
+      [[GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
   return APIResponse;
 }
 
@@ -494,7 +493,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
                                 challenge:(NSData *)challenge
                                 assertion:(NSData *)assertion
                                limitedUse:(BOOL)limitedUse
-                                 response:(nullable GULURLSessionDataResponse *)response
+                                 response:(nullable GACURLSessionDataResponse *)response
                                     error:(nullable NSError *)error {
   id URLValidationArg = [self URLValidationArgumentWithCustomMethod:@"exchangeAppAttestAssertion"];
 
@@ -550,7 +549,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
       .andReturn(responsePromise);
 }
 
-- (void)expectTokenWithAPIReponse:(nonnull GULURLSessionDataResponse *)response
+- (void)expectTokenWithAPIReponse:(nonnull GACURLSessionDataResponse *)response
                     toReturnToken:(nullable GACAppCheckToken *)token {
   FBLPromise *tokenPromise = [FBLPromise pendingPromise];
   if (token) {
@@ -566,7 +565,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
                                         keyID:(NSString *)keyID
                                     challenge:(NSData *)challenge
                                    limitedUse:(BOOL)limitedUse
-                                     response:(nullable GULURLSessionDataResponse *)response
+                                     response:(nullable GACURLSessionDataResponse *)response
                                         error:(nullable NSError *)error {
   id URLValidationArg =
       [self URLValidationArgumentWithCustomMethod:@"exchangeAppAttestAttestation"];

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/Storage/GACAppAttestArtifactStorageTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/Storage/GACAppAttestArtifactStorageTests.m
@@ -141,10 +141,11 @@ static NSString *const kAppID = @"1:100000000000:ios:aaaaaaaaaaaaaaaaaaaaaaaa";
 
   // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
+  id completionArg = [OCMArg invokeBlockWithArgs:[NSNull null], gulsKeychainError, nil];
   OCMExpect([mockKeychainStorage getObjectForKey:[OCMArg any]
                                      objectClass:[OCMArg any]
-                                     accessGroup:[OCMArg any]])
-      .andReturn([FBLPromise resolvedWith:gulsKeychainError]);
+                                     accessGroup:[OCMArg any]
+            									 completionHandler:completionArg]);
 
   // 3. Get artifact and verify results.
   __auto_type getPromise = [artifactStorage getArtifactForKey:@"key"];
@@ -166,11 +167,12 @@ static NSString *const kAppID = @"1:100000000000:ios:aaaaaaaaaaaaaaaaaaaaaaaa";
                                                  accessGroup:nil];
   // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
+  id completionArg = [OCMArg invokeBlockWithArgs:[NSNull null], gulsKeychainError, nil];
   OCMExpect([mockKeychainStorage setObject:[OCMArg any]
                                     forKey:[OCMArg any]
-                               accessGroup:[OCMArg any]])
-      .andReturn([FBLPromise resolvedWith:gulsKeychainError]);
-
+                               accessGroup:[OCMArg any]
+                         completionHandler:completionArg]);
+  
   // 3. Set artifact and verify results.
   NSData *artifact = [@"artifact" dataUsingEncoding:NSUTF8StringEncoding];
   __auto_type setPromise = [artifactStorage setArtifact:artifact forKey:@"key"];
@@ -193,8 +195,8 @@ static NSString *const kAppID = @"1:100000000000:ios:aaaaaaaaaaaaaaaaaaaaaaaa";
 
   // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
-  OCMExpect([mockKeychainStorage removeObjectForKey:[OCMArg any] accessGroup:[OCMArg any]])
-      .andReturn([FBLPromise resolvedWith:gulsKeychainError]);
+  id completionArg = [OCMArg invokeBlockWithArgs:@NO, gulsKeychainError, nil];
+  OCMExpect([mockKeychainStorage removeObjectForKey:[OCMArg any] accessGroup:[OCMArg any] completionHandler:completionArg]);
 
   // 3. Remove artifact and verify results.
   __auto_type setPromise = [artifactStorage setArtifact:nil forKey:@"key"];

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/Storage/GACAppAttestArtifactStorageTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/Storage/GACAppAttestArtifactStorageTests.m
@@ -145,7 +145,7 @@ static NSString *const kAppID = @"1:100000000000:ios:aaaaaaaaaaaaaaaaaaaaaaaa";
   OCMExpect([mockKeychainStorage getObjectForKey:[OCMArg any]
                                      objectClass:[OCMArg any]
                                      accessGroup:[OCMArg any]
-            									 completionHandler:completionArg]);
+                               completionHandler:completionArg]);
 
   // 3. Get artifact and verify results.
   __auto_type getPromise = [artifactStorage getArtifactForKey:@"key"];
@@ -172,7 +172,7 @@ static NSString *const kAppID = @"1:100000000000:ios:aaaaaaaaaaaaaaaaaaaaaaaa";
                                     forKey:[OCMArg any]
                                accessGroup:[OCMArg any]
                          completionHandler:completionArg]);
-  
+
   // 3. Set artifact and verify results.
   NSData *artifact = [@"artifact" dataUsingEncoding:NSUTF8StringEncoding];
   __auto_type setPromise = [artifactStorage setArtifact:artifact forKey:@"key"];
@@ -196,7 +196,9 @@ static NSString *const kAppID = @"1:100000000000:ios:aaaaaaaaaaaaaaaaaaaaaaaa";
   // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
   id completionArg = [OCMArg invokeBlockWithArgs:@NO, gulsKeychainError, nil];
-  OCMExpect([mockKeychainStorage removeObjectForKey:[OCMArg any] accessGroup:[OCMArg any] completionHandler:completionArg]);
+  OCMExpect([mockKeychainStorage removeObjectForKey:[OCMArg any]
+                                        accessGroup:[OCMArg any]
+                                  completionHandler:completionArg]);
 
   // 3. Remove artifact and verify results.
   __auto_type setPromise = [artifactStorage setArtifact:nil forKey:@"key"];

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/Storage/GACAppAttestArtifactStorageTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/Storage/GACAppAttestArtifactStorageTests.m
@@ -195,7 +195,7 @@ static NSString *const kAppID = @"1:100000000000:ios:aaaaaaaaaaaaaaaaaaaaaaaa";
 
   // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
-  id completionArg = [OCMArg invokeBlockWithArgs:@NO, gulsKeychainError, nil];
+  id completionArg = [OCMArg invokeBlockWithArgs:gulsKeychainError, nil];
   OCMExpect([mockKeychainStorage removeObjectForKey:[OCMArg any]
                                         accessGroup:[OCMArg any]
                                   completionHandler:completionArg]);

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
@@ -19,7 +19,7 @@
 #import <OCMock/OCMock.h>
 #import "FBLPromise+Testing.h"
 
-#import <GoogleUtilities/GULURLSessionDataResponse.h>
+#import <GoogleUtilities/GACURLSessionDataResponse.h>
 #import <GoogleUtilities/NSURLSession+GULPromises.h>
 
 #import "AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.h"
@@ -333,8 +333,8 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
       [GACFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
   XCTAssertNotNil(responseBody);
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
-  GULURLSessionDataResponse *APIResponse =
-      [[GULURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
+  GACURLSessionDataResponse *APIResponse =
+      [[GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
 
   // 2. Expected result.
   NSString *expectedFACToken = @"valid_app_check_token";
@@ -359,8 +359,8 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   NSString *responseBodyString = @"Token verification failed.";
   NSData *responseBody = [responseBodyString dataUsingEncoding:NSUTF8StringEncoding];
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
-  GULURLSessionDataResponse *APIResponse =
-      [[GULURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
+  GACURLSessionDataResponse *APIResponse =
+      [[GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
 
   // 2. Parse API response.
   __auto_type tokenPromise = [self.APIService appCheckTokenWithAPIResponse:APIResponse];
@@ -394,8 +394,8 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   XCTAssertNotNil(missingFiledBody);
 
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
-  GULURLSessionDataResponse *APIResponse =
-      [[GULURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:missingFiledBody];
+  GACURLSessionDataResponse *APIResponse =
+      [[GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:missingFiledBody];
 
   // 2. Parse API response.
   __auto_type tokenPromise = [self.APIService appCheckTokenWithAPIResponse:APIResponse];
@@ -435,17 +435,17 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   id URLRequestValidationArg = [OCMArg checkWithBlock:nonOptionalRequestValidationBlock];
 
   // Result promise.
-  FBLPromise<GULURLSessionDataResponse *> *result = [FBLPromise pendingPromise];
+  FBLPromise<GACURLSessionDataResponse *> *result = [FBLPromise pendingPromise];
   if (error == nil) {
-    GULURLSessionDataResponse *response =
-        [[GULURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:body];
+    GACURLSessionDataResponse *response =
+        [[GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:body];
     [result fulfill:response];
   } else {
     [result reject:error];
   }
 
   // Stub the method.
-  OCMExpect([URLSessionMock gul_dataTaskPromiseWithRequest:URLRequestValidationArg])
+  OCMExpect([URLSessionMock gac_dataTaskPromiseWithRequest:URLRequestValidationArg])
       .andReturn(result);
 }
 

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
@@ -19,10 +19,9 @@
 #import <OCMock/OCMock.h>
 #import "FBLPromise+Testing.h"
 
-#import <GoogleUtilities/GACURLSessionDataResponse.h>
-#import <GoogleUtilities/NSURLSession+GULPromises.h>
-
 #import "AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.h"
+#import "AppCheckCore/Sources/Core/APIService/NSURLSession+GACPromises.h"
+#import "AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.h"
 #import "AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckErrors.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckToken.h"

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
@@ -20,8 +20,8 @@
 #import "FBLPromise+Testing.h"
 
 #import "AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.h"
-#import "AppCheckCore/Sources/Core/APIService/NSURLSession+GACPromises.h"
 #import "AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.h"
+#import "AppCheckCore/Sources/Core/APIService/NSURLSession+GACPromises.h"
 #import "AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckErrors.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckToken.h"

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckBackoffWrapperTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckBackoffWrapperTests.m
@@ -361,8 +361,8 @@
                                       errorHandler:self.errorHandler];
 
   // 1.5 Wait for operation to complete.
-  [self waitForExpectationsWithTimeout:1.0 handler:NULL];
-  XCTAssert(FBLWaitForPromisesWithTimeout(1.0));
+  [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+  XCTAssert(FBLWaitForPromisesWithTimeout(5.0));
 
   // 1.6 Expect the promise to be rejected with a backoff error.
   XCTAssertTrue(operationWithBackoff.isRejected);
@@ -381,8 +381,8 @@
                                                          errorHandler:self.errorHandler];
 
   // 2.4 Wait for operation to complete.
-  [self waitForExpectationsWithTimeout:1.0 handler:NULL];
-  XCTAssert(FBLWaitForPromisesWithTimeout(1.0));
+  [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+  XCTAssert(FBLWaitForPromisesWithTimeout(5.0));
 
   // 2.5 Expect the promise to be rejected with a backoff error.
   XCTAssertTrue(operationWithBackoff.isRejected);

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckStorageTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckStorageTests.m
@@ -98,7 +98,7 @@ static NSString *const kGoogleAppID = @"1:100000000000:ios:aaaaaaaaaaaaaaaaaaaaa
                                                                  accessGroup:nil];
   // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
-  id completionArg = [OCMArg invokeBlockWithArgs:[NSNull null], gulsKeychainError, nil];
+  id completionArg = [OCMArg invokeBlockWithArgs:gulsKeychainError, nil];
   OCMExpect([mockKeychainStorage getObjectForKey:[OCMArg any]
                                      objectClass:[OCMArg any]
                                      accessGroup:[OCMArg any]
@@ -124,7 +124,7 @@ static NSString *const kGoogleAppID = @"1:100000000000:ios:aaaaaaaaaaaaaaaaaaaaa
 
   // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
-  id completionArg = [OCMArg invokeBlockWithArgs:[NSNull null], gulsKeychainError, nil];
+  id completionArg = [OCMArg invokeBlockWithArgs:gulsKeychainError, nil];
   OCMExpect([mockKeychainStorage setObject:[OCMArg any]
                                     forKey:[OCMArg any]
                                accessGroup:[OCMArg any]
@@ -152,7 +152,7 @@ static NSString *const kGoogleAppID = @"1:100000000000:ios:aaaaaaaaaaaaaaaaaaaaa
                                                                  accessGroup:nil];
   // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
-  id completionArg = [OCMArg invokeBlockWithArgs:@NO, gulsKeychainError, nil];
+  id completionArg = [OCMArg invokeBlockWithArgs:gulsKeychainError, nil];
   OCMExpect([mockKeychainStorage removeObjectForKey:[OCMArg any]
                                         accessGroup:[OCMArg any]
                                   completionHandler:completionArg]);

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckStorageTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckStorageTests.m
@@ -98,10 +98,11 @@ static NSString *const kGoogleAppID = @"1:100000000000:ios:aaaaaaaaaaaaaaaaaaaaa
                                                                  accessGroup:nil];
   // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
+  id completionArg = [OCMArg invokeBlockWithArgs:[NSNull null], gulsKeychainError, nil];
   OCMExpect([mockKeychainStorage getObjectForKey:[OCMArg any]
                                      objectClass:[OCMArg any]
-                                     accessGroup:[OCMArg any]])
-      .andReturn([FBLPromise resolvedWith:gulsKeychainError]);
+                                     accessGroup:[OCMArg any]
+                               completionHandler:completionArg]);
 
   // 3. Get token and verify results.
   __auto_type getPromise = [storage getToken];
@@ -123,10 +124,11 @@ static NSString *const kGoogleAppID = @"1:100000000000:ios:aaaaaaaaaaaaaaaaaaaaa
 
   // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
+  id completionArg = [OCMArg invokeBlockWithArgs:[NSNull null], gulsKeychainError, nil];
   OCMExpect([mockKeychainStorage setObject:[OCMArg any]
                                     forKey:[OCMArg any]
-                               accessGroup:[OCMArg any]])
-      .andReturn([FBLPromise resolvedWith:gulsKeychainError]);
+                               accessGroup:[OCMArg any]
+                         completionHandler:completionArg]);
 
   // 3. Set token and verify results.
   GACAppCheckToken *tokenToStore = [[GACAppCheckToken alloc] initWithToken:@"token"
@@ -148,11 +150,12 @@ static NSString *const kGoogleAppID = @"1:100000000000:ios:aaaaaaaaaaaaaaaaaaaaa
   GACAppCheckStorage *storage = [[GACAppCheckStorage alloc] initWithTokenKey:self.tokenKey
                                                              keychainStorage:mockKeychainStorage
                                                                  accessGroup:nil];
-
   // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
-  OCMExpect([mockKeychainStorage removeObjectForKey:[OCMArg any] accessGroup:[OCMArg any]])
-      .andReturn([FBLPromise resolvedWith:gulsKeychainError]);
+  id completionArg = [OCMArg invokeBlockWithArgs:@NO, gulsKeychainError, nil];
+  OCMExpect([mockKeychainStorage removeObjectForKey:[OCMArg any]
+                                        accessGroup:[OCMArg any]
+                                  completionHandler:completionArg]);
 
   // 3. Remove token and verify results.
   __auto_type getPromise = [storage setToken:nil];

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckStorageTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckStorageTests.m
@@ -98,7 +98,7 @@ static NSString *const kGoogleAppID = @"1:100000000000:ios:aaaaaaaaaaaaaaaaaaaaa
                                                                  accessGroup:nil];
   // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
-  id completionArg = [OCMArg invokeBlockWithArgs:gulsKeychainError, nil];
+  id completionArg = [OCMArg invokeBlockWithArgs:[NSNull null], gulsKeychainError, nil];
   OCMExpect([mockKeychainStorage getObjectForKey:[OCMArg any]
                                      objectClass:[OCMArg any]
                                      accessGroup:[OCMArg any]
@@ -124,7 +124,7 @@ static NSString *const kGoogleAppID = @"1:100000000000:ios:aaaaaaaaaaaaaaaaaaaaa
 
   // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
-  id completionArg = [OCMArg invokeBlockWithArgs:gulsKeychainError, nil];
+  id completionArg = [OCMArg invokeBlockWithArgs:[NSNull null], gulsKeychainError, nil];
   OCMExpect([mockKeychainStorage setObject:[OCMArg any]
                                     forKey:[OCMArg any]
                                accessGroup:[OCMArg any]

--- a/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderAPIServiceTests.m
@@ -22,9 +22,8 @@
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckToken.h"
 
-#import <GoogleUtilities/GULURLSessionDataResponse.h>
-
 #import "AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.h"
+#import "AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.h"
 #import "AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 #import "AppCheckCore/Sources/DebugProvider/API/GACAppCheckDebugProviderAPIService.h"
 
@@ -85,8 +84,8 @@ static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_
                                                             limitedUse:limitedUse];
   NSData *fakeResponseData = [@"fake response" dataUsingEncoding:NSUTF8StringEncoding];
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
-  GULURLSessionDataResponse *APIResponse =
-      [[GULURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:fakeResponseData];
+  GACURLSessionDataResponse *APIResponse =
+      [[GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:fakeResponseData];
 
   OCMExpect([self.mockAPIService sendRequestWithURL:URLValidationArg
                                          HTTPMethod:@"POST"
@@ -133,8 +132,8 @@ static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_
   id HTTPBodyValidationArg = [self HTTPBodyValidationArgWithDebugToken:debugToken limitedUse:NO];
   NSData *fakeResponseData = [@"fake response" dataUsingEncoding:NSUTF8StringEncoding];
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
-  GULURLSessionDataResponse *APIResponse =
-      [[GULURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:fakeResponseData];
+  GACURLSessionDataResponse *APIResponse =
+      [[GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:fakeResponseData];
 
   OCMExpect([self.mockAPIService sendRequestWithURL:URLValidationArg
                                          HTTPMethod:@"POST"

--- a/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
@@ -19,9 +19,8 @@
 #import <OCMock/OCMock.h>
 #import "FBLPromise+Testing.h"
 
-#import <GoogleUtilities/GULURLSessionDataResponse.h>
-
 #import "AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.h"
+#import "AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.h"
 #import "AppCheckCore/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 #import "AppCheckCore/Sources/DeviceCheckProvider/API/GACDeviceCheckAPIService.h"
 #import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckErrors.h"
@@ -92,8 +91,8 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
   XCTAssertNotNil(responseBody);
 
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
-  GULURLSessionDataResponse *APIResponse =
-      [[GULURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
+  GACURLSessionDataResponse *APIResponse =
+      [[GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
 
   OCMExpect([self.mockAPIService sendRequestWithURL:URLValidationArg
                                          HTTPMethod:@"POST"
@@ -145,8 +144,8 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
   XCTAssertNotNil(responseBody);
 
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
-  GULURLSessionDataResponse *APIResponse =
-      [[GULURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
+  GACURLSessionDataResponse *APIResponse =
+      [[GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
 
   OCMExpect([self.mockAPIService sendRequestWithURL:URLValidationArg
                                          HTTPMethod:@"POST"


### PR DESCRIPTION
Context: `GULURLSessionDataResponse` removed in https://github.com/google/GoogleUtilities/pull/187.