### PR TITLE
Don't use [self class] in an initializer

### DIFF
--- a/AppCheckCore/Sources/Core/GACAppCheckTokenResult.m
+++ b/AppCheckCore/Sources/Core/GACAppCheckTokenResult.m
@@ -38,7 +38,7 @@ static NSString *const kPlaceholderTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1
 }
 
 - (instancetype)initWithError:(NSError *)error {
-  return [self initWithToken:[[self class] placeholderToken] error:error];
+  return [self initWithToken:[GACAppCheckTokenResult placeholderToken] error:error];
 }
 
 #pragma mark - Internal

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,6 @@ source 'https://rubygems.org'
 # gem 'cocoapods-core', git: "https://github.com/CocoaPods/Core.git", ref: "f7cf05720eab935d7d50e35224d263952176fb53"
 # gem 'xcodeproj', git: "https://github.com/CocoaPods/Xcodeproj.git", ref: "eeccae7275645753cbaf45d96fc4b23e4b8b3b9f"
 
-gem 'cocoapods', '1.14.2'
+gem 'cocoapods', '1.15.2'
 gem 'cocoapods-generate', '2.2.5'
 gem 'danger', '8.4.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.6)
+    CFPropertyList (3.0.7)
+      base64
+      nkf
       rexml
-    activesupport (7.1.1)
+    activesupport (7.1.3.4)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -19,19 +21,19 @@ GEM
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
-    base64 (0.1.1)
-    bigdecimal (3.1.4)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
     claide (1.0.3)
     claide-plugins (0.9.2)
       cork
       nap
       open4 (~> 1.3)
-    cocoapods (1.14.2)
+    cocoapods (1.15.2)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.14.2)
+      cocoapods-core (= 1.15.2)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 2.0)
+      cocoapods-downloader (>= 2.1, < 3.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
       cocoapods-trunk (>= 1.6.0, < 2.0)
@@ -44,7 +46,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
       xcodeproj (>= 1.23.0, < 2.0)
-    cocoapods-core (1.14.2)
+    cocoapods-core (1.15.2)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -56,7 +58,7 @@ GEM
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.5)
     cocoapods-disable-podfile-validations (0.2.0)
-    cocoapods-downloader (2.0)
+    cocoapods-downloader (2.1)
     cocoapods-generate (2.2.5)
       cocoapods-disable-podfile-validations (>= 0.1.1, < 0.3.0)
     cocoapods-plugins (1.0.0)
@@ -67,7 +69,7 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     cork (0.3.0)
       colored2 (~> 3.1)
@@ -84,8 +86,7 @@ GEM
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (>= 1, < 4)
-    drb (2.1.1)
-      ruby2_keywords
+    drb (2.2.1)
     escape (0.0.4)
     ethon (0.16.0)
       ffi (>= 1.15.0)
@@ -114,7 +115,7 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    ffi (1.16.3)
+    ffi (1.17.0)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -122,20 +123,21 @@ GEM
       addressable (~> 2.8)
       rchardet (~> 1.8)
     httpclient (2.8.3)
-    i18n (1.14.1)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
-    json (2.6.3)
+    json (2.7.2)
     kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    minitest (5.20.0)
+    minitest (5.23.1)
     molinillo (0.8.0)
     multipart-post (2.1.1)
-    mutex_m (0.1.2)
+    mutex_m (0.2.0)
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
+    nkf (0.2.0)
     no_proxy_fix (0.1.2)
     octokit (4.22.0)
       faraday (>= 0.9)
@@ -153,12 +155,12 @@ GEM
     strscan (3.1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    typhoeus (1.4.0)
+    typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
-    xcodeproj (1.23.0)
+    xcodeproj (1.24.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -170,7 +172,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (= 1.14.2)
+  cocoapods (= 1.15.2)
   cocoapods-generate (= 2.2.5)
   danger (= 8.4.5)
 


### PR DESCRIPTION
See the `Don’t Use Accessor Methods in Initializer Methods and dealloc` section at https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/mmPractical.html

This may address https://github.com/firebase/firebase-ios-sdk/issues/12365