### PR TITLE
Depend on `main` branch of GoogleUtilities

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
     ),
     .package(
       url: "https://github.com/google/GoogleUtilities.git",
-      branch: "release-8.0"
+      branch: "main"
       // TODO: Enable after GULs v8 publishes.
       // "8.0.0" ..< "9.0.0"
     ),


### PR DESCRIPTION
The `release-8.0` branch of GoogleUtilities has been [merged](https://github.com/google/GoogleUtilities/commit/e70da7c48a91b49429385dd3964025edd6ef9c25) into `main`.