### PR TITLE
[AppCheck] Reset to attestation flow if assertion flow fails

### DIFF
--- a/AppCheckCore/Sources/AppAttestProvider/Errors/GACAppAttestRejectionError.h
+++ b/AppCheckCore/Sources/AppAttestProvider/Errors/GACAppAttestRejectionError.h
@@ -20,7 +20,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface GACAppAttestRejectionError : NSError
 
+@property(nonatomic, readonly) NSError *underlyingError;
+
 - (instancetype)init;
+- (instancetype)initWithUnderlyingError:(NSError *)underlyingError;
 
 @end
 

--- a/AppCheckCore/Sources/AppAttestProvider/Errors/GACAppAttestRejectionError.h
+++ b/AppCheckCore/Sources/AppAttestProvider/Errors/GACAppAttestRejectionError.h
@@ -22,8 +22,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, readonly) NSError *underlyingError;
 
-- (instancetype)init;
 - (instancetype)initWithUnderlyingError:(NSError *)underlyingError;
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithDomain:(NSErrorDomain)domain
+                          code:(NSInteger)code
+                      userInfo:(nullable NSDictionary<NSErrorUserInfoKey, id> *)dict NS_UNAVAILABLE;
+- (instancetype)initWithCoder:(NSCoder *)coder NS_UNAVAILABLE;
 
 @end
 

--- a/AppCheckCore/Sources/AppAttestProvider/Errors/GACAppAttestRejectionError.m
+++ b/AppCheckCore/Sources/AppAttestProvider/Errors/GACAppAttestRejectionError.m
@@ -22,8 +22,18 @@
 
 @implementation GACAppAttestRejectionError
 
+- (NSError *)underlyingError {
+  return self.userInfo[NSUnderlyingErrorKey];
+}
+
 - (instancetype)init {
   return [self initWithDomain:GACAppCheckErrorDomain code:GACAppCheckErrorCodeUnknown userInfo:nil];
+}
+
+- (instancetype)initWithUnderlyingError:(NSError *)underlyingError {
+  return [self initWithDomain:GACAppCheckErrorDomain
+                         code:GACAppCheckErrorCodeUnknown
+                     userInfo:@{NSUnderlyingErrorKey : underlyingError}];
 }
 
 @end

--- a/AppCheckCore/Sources/AppAttestProvider/Errors/GACAppAttestRejectionError.m
+++ b/AppCheckCore/Sources/AppAttestProvider/Errors/GACAppAttestRejectionError.m
@@ -26,10 +26,6 @@
   return self.userInfo[NSUnderlyingErrorKey];
 }
 
-- (instancetype)init {
-  return [self initWithDomain:GACAppCheckErrorDomain code:GACAppCheckErrorCodeUnknown userInfo:nil];
-}
-
 - (instancetype)initWithUnderlyingError:(NSError *)underlyingError {
   return [self initWithDomain:GACAppCheckErrorDomain
                          code:GACAppCheckErrorCodeUnknown

--- a/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -250,49 +250,62 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (FBLPromise<GACAppCheckToken *> *)createGetTokenSequencePromiseWithLimitedUse:(BOOL)limitedUse {
   // Check attestation state to decide on the next steps.
-  return [self attestationState].thenOn(self.queue, ^id(GACAppAttestProviderState *attestState) {
-    switch (attestState.state) {
-      case GACAppAttestAttestationStateUnsupported:
-        GACAppCheckLogDebug(GACLoggerAppCheckMessageCodeAppAttestNotSupported,
-                            @"App Attest is not supported.");
-        return attestState.appAttestUnsupportedError;
-        break;
+  return [FBLPromise onQueue:self.queue
+             attempts:1
+             delay:0
+             condition:^BOOL(NSInteger, NSError *_Nonnull error) {
+               return [error isKindOfClass:[GACAppAttestRejectionError class]];
+             }
+             retry:^id {
+               return [self attestationState].thenOn(
+                   self.queue, ^id(GACAppAttestProviderState *attestState) {
+                     switch (attestState.state) {
+                       case GACAppAttestAttestationStateUnsupported:
+                         GACAppCheckLogDebug(GACLoggerAppCheckMessageCodeAppAttestNotSupported,
+                                             @"App Attest is not supported.");
+                         return attestState.appAttestUnsupportedError;
+                         break;
 
-      case GACAppAttestAttestationStateSupportedInitial:
-      case GACAppAttestAttestationStateKeyGenerated:
-        // Initial handshake is required for both the "initial" and the "key generated" states.
-        return [self initialHandshakeWithKeyID:attestState.appAttestKeyID limitedUse:limitedUse];
-        break;
+                       case GACAppAttestAttestationStateSupportedInitial:
+                       case GACAppAttestAttestationStateKeyGenerated:
+                         // Initial handshake is required for both the "initial" and the "key
+                         // generated" states.
+                         return [self initialHandshakeWithKeyID:attestState.appAttestKeyID
+                                                     limitedUse:limitedUse];
+                         break;
 
-      case GACAppAttestAttestationStateKeyRegistered:
-        // Refresh FAC token using the existing registered App Attest key pair.
-        return [self refreshTokenWithKeyID:attestState.appAttestKeyID
-                                  artifact:attestState.attestationArtifact
-                                limitedUse:limitedUse];
-        break;
-    }
-  });
+                       case GACAppAttestAttestationStateKeyRegistered:
+                         // Refresh FAC token using the existing registered App Attest key pair.
+                         return [self refreshTokenWithKeyID:attestState.appAttestKeyID
+                                                   artifact:attestState.attestationArtifact
+                                                 limitedUse:limitedUse];
+                         break;
+                     }
+                   });
+             }]
+      .recoverOn(self.queue, ^id(NSError *error) {
+        if ([error isKindOfClass:[GACAppAttestRejectionError class]]) {
+          // The error was wrapped to indicate that it should be retried. The
+          // retry failed so throw the wrapped error.
+          return [(GACAppAttestRejectionError *)error underlyingError];
+        } else {
+          // Otherwise just re-throw the error.
+          return error;
+        }
+      });
+  ;
 }
 
 #pragma mark - Initial handshake sequence (attestation)
 
 - (FBLPromise<GACAppCheckToken *> *)initialHandshakeWithKeyID:(nullable NSString *)keyID
                                                    limitedUse:(BOOL)limitedUse {
-  // 1. Attest the device. Retry once on 403 from Firebase backend (attestation rejection error).
-  __block NSString *keyIDForAttempt = keyID;
-  return [FBLPromise onQueue:self.queue
-             attempts:1
-             delay:0
-             condition:^BOOL(NSInteger attemptCount, NSError *_Nonnull error) {
-               // Reset keyID before retrying.
-               keyIDForAttempt = nil;
-               return [error isKindOfClass:[GACAppAttestRejectionError class]];
-             }
-             retry:^FBLPromise<NSArray * /*[keyID, attestArtifact]*/> *_Nullable {
-               return [self attestKeyGenerateIfNeededWithID:keyIDForAttempt limitedUse:limitedUse];
-             }]
-      .thenOn(self.queue, ^FBLPromise<GACAppCheckToken *> *(NSArray *attestationResults) {
-        // 4. Save the artifact and return the received FAC token.
+  // Attest the device. Attestation rejection errors will be bubbled up to this
+  // method's caller and retried.
+  return [self attestKeyGenerateIfNeededWithID:keyID limitedUse:limitedUse].thenOn(
+      self.queue,
+      ^FBLPromise<GACAppCheckToken *> *(NSArray * /*[keyID, attestArtifact]*/ attestationResults) {
+        // Save the artifact and return the received FAC token.
 
         GACAppAttestKeyAttestationResult *attestation = attestationResults.firstObject;
         GACAppAttestAttestationResponse *firebaseAttestationResponse =
@@ -379,7 +392,7 @@ NS_ASSUME_NONNULL_BEGIN
                      // Reset the attestation.
                      return [self resetAttestation].thenOn(self.queue, ^NSError *(id result) {
                        // Throw the rejection error.
-                       return [[GACAppAttestRejectionError alloc] init];
+                       return [[GACAppAttestRejectionError alloc] initWithUnderlyingError:error];
                      });
                    }
 
@@ -413,7 +426,7 @@ NS_ASSUME_NONNULL_BEGIN
           // Reset the attestation.
           return [self resetAttestation].thenOn(self.queue, ^NSError *(id result) {
             // Throw the rejection error.
-            return [[GACAppAttestRejectionError alloc] init];
+            return [[GACAppAttestRejectionError alloc] initWithUnderlyingError:error];
           });
         }
 
@@ -463,23 +476,47 @@ NS_ASSUME_NONNULL_BEGIN
                     // 1.2. Get the statement SHA256 hash.
                     return [GACAppCheckCryptoUtils sha256HashFromData:[statementForAssertion copy]];
                   }]
-      .thenOn(self.queue,
-              ^FBLPromise<NSData *> *(NSData *statementHash) {
-                // 2. Generate App Attest assertion.
-                return [FBLPromise onQueue:self.queue
-                           wrapObjectOrErrorCompletion:^(
-                               FBLPromiseObjectOrErrorCompletion _Nonnull handler) {
-                             [self.appAttestService generateAssertion:keyID
-                                                       clientDataHash:statementHash
-                                                    completionHandler:handler];
-                           }]
-                    .recoverOn(self.queue, ^id(NSError *error) {
-                      return [GACAppCheckErrorUtil
-                          appAttestGenerateAssertionFailedWithError:error
-                                                              keyId:keyID
-                                                     clientDataHash:statementHash];
+      .thenOn(
+          self.queue,
+          ^FBLPromise<NSData *> *(NSData *statementHash) {
+            // 2. Generate App Attest assertion.
+            return [FBLPromise onQueue:self.queue
+                       wrapObjectOrErrorCompletion:^(
+                           FBLPromiseObjectOrErrorCompletion _Nonnull handler) {
+                         [self.appAttestService generateAssertion:keyID
+                                                   clientDataHash:statementHash
+                                                completionHandler:handler];
+                       }]
+                .recoverOn(self.queue, ^id(NSError *appAttestError) {
+                  NSError *error = [GACAppCheckErrorUtil
+                      appAttestGenerateAssertionFailedWithError:appAttestError
+                                                          keyId:keyID
+                                                 clientDataHash:statementHash];
+
+                  // If Apple rejected the key (DCErrorInvalidKey or
+                  // DCErrorInvalidInput) then reset the attestation and
+                  // throw a specific error to signal retry (GACAppAttestRejectionError).
+                  NSError *underlyingError = error.userInfo[NSUnderlyingErrorKey];
+                  if (underlyingError && [underlyingError.domain isEqualToString:DCErrorDomain] &&
+                      (underlyingError.code == DCErrorInvalidKey ||
+                       underlyingError.code == DCErrorInvalidInput)) {
+                    NSString *logMessage = [NSString
+                        stringWithFormat:@"App Attest invalid key/input; the existing attestation "
+                                         @"will be reset. DC Error Code: %@.",
+                                         @(underlyingError.code)];
+                    GACAppCheckLog(GACLoggerAppCheckMessageCodeAssertionRejected,
+                                   GACAppCheckLogLevelDebug, logMessage);
+                    // Reset the attestation.
+                    return [self resetAttestation].thenOn(self.queue, ^NSError *(id result) {
+                      // Throw the rejection error.
+                      return [[GACAppAttestRejectionError alloc] initWithUnderlyingError:error];
                     });
-              })
+                  }
+
+                  // Otherwise just re-throw the error.
+                  return error;
+                });
+          })
       // 3. Compose the result object.
       .thenOn(self.queue, ^GACAppAttestAssertionData *(NSData *assertion) {
         return [[GACAppAttestAssertionData alloc] initWithChallenge:challenge

--- a/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -253,7 +253,7 @@ NS_ASSUME_NONNULL_BEGIN
   return [FBLPromise onQueue:self.queue
              attempts:1
              delay:0
-             condition:^BOOL(NSInteger, NSError *_Nonnull error) {
+             condition:^BOOL(NSInteger attempts, NSError *_Nonnull error) {
                return [error isKindOfClass:[GACAppAttestRejectionError class]];
              }
              retry:^id {

--- a/AppCheckCore/Sources/Core/GACAppCheck.m
+++ b/AppCheckCore/Sources/Core/GACAppCheck.m
@@ -139,7 +139,7 @@ typedef void (^GACAppCheckTokenHandler)(GACAppCheckTokenResult *result);
     if (self.ongoingRetrieveOrRefreshTokenPromise == nil) {
       // Kick off a new operation only when there is not an ongoing one.
       self.ongoingRetrieveOrRefreshTokenPromise =
-          [self createRetrieveOrRefreshTokenPromiseForcingRefresh:YES]
+          [self createRetrieveOrRefreshTokenPromiseForcingRefresh:forcingRefresh]
 
               // Release the ongoing operation promise on completion.
               .then(^GACAppCheckToken *(GACAppCheckToken *token) {

--- a/AppCheckCore/Sources/Core/GACAppCheck.m
+++ b/AppCheckCore/Sources/Core/GACAppCheck.m
@@ -139,7 +139,7 @@ typedef void (^GACAppCheckTokenHandler)(GACAppCheckTokenResult *result);
     if (self.ongoingRetrieveOrRefreshTokenPromise == nil) {
       // Kick off a new operation only when there is not an ongoing one.
       self.ongoingRetrieveOrRefreshTokenPromise =
-          [self createRetrieveOrRefreshTokenPromiseForcingRefresh:forcingRefresh]
+          [self createRetrieveOrRefreshTokenPromiseForcingRefresh:YES]
 
               // Release the ongoing operation promise on completion.
               .then(^GACAppCheckToken *(GACAppCheckToken *token) {

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckErrors.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckErrors.h
@@ -55,5 +55,6 @@ typedef NS_ENUM(NSInteger, GACAppCheckMessageCode) {
 
   // App Attest Provider
   GACLoggerAppCheckMessageCodeAppAttestNotSupported = 7001,
-  GACLoggerAppCheckMessageCodeAttestationRejected = 7002
+  GACLoggerAppCheckMessageCodeAttestationRejected = 7002,
+  GACLoggerAppCheckMessageCodeAssertionRejected = 7003
 } NS_SWIFT_NAME(AppCheckCoreMessageCode);

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
@@ -520,12 +520,15 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
   // 4. Stored attestation to be reset.
   [self expectAttestationReset];
 
-  // 5. Expect the App Attest key pair to be generated and attested.
+  // 5. Expect App Attest availability to be requested and stored key ID request to fail.
+  [self expectAppAttestAvailabilityToBeCheckedAndNotExistingStoredKeyRequested];
+
+  // 6. Expect the App Attest key pair to be generated and attested.
   NSString *keyID2 = @"keyID2";
   NSData *attestationData2 = [[NSUUID UUID].UUIDString dataUsingEncoding:NSUTF8StringEncoding];
   [self expectAppAttestKeyGeneratedAndAttestedWithKeyID:keyID2 attestationData:attestationData2];
 
-  // 6. Expect exchange request to be sent.
+  // 7. Expect exchange request to be sent.
   GACAppCheckToken *FACToken = [[GACAppCheckToken alloc] initWithToken:@"FAC token"
                                                         expirationDate:[NSDate date]];
   NSData *artifactData = [@"attestation artifact" dataUsingEncoding:NSUTF8StringEncoding];
@@ -541,11 +544,11 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
                                                 challenge:OCMOCK_ANY
                                                limitedUse:YES]);
 
-  // 7. Expect the artifact received from Firebase backend to be saved.
+  // 8. Expect the artifact received from Firebase backend to be saved.
   OCMExpect([self.mockArtifactStorage setArtifact:artifactData forKey:keyID2])
       .andReturn([FBLPromise resolvedWith:artifactData]);
 
-  // 8. Call get token.
+  // 9. Call get token.
   XCTestExpectation *completionExpectation =
       [self expectationWithDescription:@"completionExpectation"];
   [self.provider
@@ -559,7 +562,7 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
 
   [self waitForExpectations:@[ completionExpectation ] timeout:0.5 enforceOrder:YES];
 
-  // 8. Verify mocks.
+  // 10. Verify mocks.
   [self verifyAllMocks];
 }
 
@@ -587,12 +590,15 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
   // 4. Stored attestation to be reset.
   [self expectAttestationReset];
 
-  // 5. Expect the App Attest key pair to be generated and attested.
+  // 5. Expect App Attest availability to be requested and stored key ID request to fail.
+  [self expectAppAttestAvailabilityToBeCheckedAndNotExistingStoredKeyRequested];
+
+  // 6. Expect the App Attest key pair to be generated and attested.
   NSString *keyID2 = @"keyID2";
   NSData *attestationData2 = [[NSUUID UUID].UUIDString dataUsingEncoding:NSUTF8StringEncoding];
   [self expectAppAttestKeyGeneratedAndAttestedWithKeyID:keyID2 attestationData:attestationData2];
 
-  // 6. Expect exchange request to be sent.
+  // 7. Expect exchange request to be sent.
   OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData2
                                                     keyID:keyID2
                                                 challenge:self.randomChallenge
@@ -603,13 +609,13 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
                                                 challenge:OCMOCK_ANY
                                                limitedUse:YES]);
 
-  // 7. Stored attestation to be reset.
+  // 8. Stored attestation to be reset.
   [self expectAttestationReset];
 
-  // 8. Don't expect the artifact received from Firebase backend to be saved.
+  // 9. Don't expect the artifact received from Firebase backend to be saved.
   OCMReject([self.mockArtifactStorage setArtifact:OCMOCK_ANY forKey:OCMOCK_ANY]);
 
-  // 9. Call get token.
+  // 10. Call get token.
   XCTestExpectation *completionExpectation =
       [self expectationWithDescription:@"completionExpectation"];
   [self.provider
@@ -617,13 +623,13 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
         [completionExpectation fulfill];
 
         XCTAssertNil(token);
-        GACAppAttestRejectionError *expectedError = [[GACAppAttestRejectionError alloc] init];
-        XCTAssertEqualObjects(error, expectedError);
+        XCTAssertNotNil(error);
+        XCTAssert([error isKindOfClass:[GACAppCheckHTTPError class]]);
       }];
 
   [self waitForExpectations:@[ completionExpectation ] timeout:0.5 enforceOrder:YES];
 
-  // 9. Verify mocks.
+  // 11. Verify mocks.
   [self verifyAllMocks];
 }
 
@@ -1149,12 +1155,15 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
   // 6. Stored attestation to be reset.
   [self expectAttestationReset];
 
-  // 7. Expect the App Attest key pair to be generated and attested.
+  // 7. Expect App Attest availability to be requested and stored key ID request to fail.
+  [self expectAppAttestAvailabilityToBeCheckedAndNotExistingStoredKeyRequested];
+
+  // 8. Expect the App Attest key pair to be generated and attested.
   NSString *newKeyID = @"newKeyID";
   NSData *attestationData = [[NSUUID UUID].UUIDString dataUsingEncoding:NSUTF8StringEncoding];
   [self expectAppAttestKeyGeneratedAndAttestedWithKeyID:newKeyID attestationData:attestationData];
 
-  // 8. Expect exchange request to be sent.
+  // 9. Expect exchange request to be sent.
   GACAppCheckToken *appCheckToken = [[GACAppCheckToken alloc] initWithToken:@"App Check Token"
                                                              expirationDate:[NSDate date]];
   NSData *artifactData = [@"attestation artifact" dataUsingEncoding:NSUTF8StringEncoding];
@@ -1166,11 +1175,11 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
                                                limitedUse:NO])
       .andReturn([FBLPromise resolvedWith:attestKeyResponse]);
 
-  // 9. Expect the artifact received from Firebase backend to be saved.
+  // 10. Expect the artifact received from Firebase backend to be saved.
   OCMExpect([self.mockArtifactStorage setArtifact:artifactData forKey:newKeyID])
       .andReturn([FBLPromise resolvedWith:artifactData]);
 
-  // 10. Call get token.
+  // 11. Call get token.
   XCTestExpectation *completionExpectation =
       [self expectationWithDescription:@"completionExpectation"];
   [self.provider
@@ -1184,7 +1193,7 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
 
   [self waitForExpectations:@[ completionExpectation ] timeout:0.5 enforceOrder:YES];
 
-  // 11. Verify mocks.
+  // 12. Verify mocks.
   [self verifyAllMocks];
 }
 

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
@@ -757,10 +757,6 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
             invalidInputError];
 }
 
-- (void)testGetToken_WhenAssertionIsRejectedByApple_ThenResetToAttestationAndRetryOnceError {
-  // TODO
-}
-
 #pragma mark - Request merging
 
 - (void)testGetToken_WhenCalledSeveralTimesSuccess_ThenThereIsOnlyOneOngoingHandshake {

--- a/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -225,8 +225,8 @@ final class AppCheckAPITests {
 
     // MARK: - GACAppCheckErrors
 
-    let code: AppCheckCoreMessageCode = .loggerAppCheckMessageCodeAppAttestNotSupported
-    switch code {
+    let code: AppCheckCoreMessageCode! = nil
+    switch code! {
     case .loggerAppCheckMessageCodeUnknown: break
     case .loggerAppCheckMessageCodeProviderIsMissing: break
     case .loggerAppCheckMessageCodeUnexpectedHTTPCode: break

--- a/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -222,6 +222,23 @@ final class AppCheckAPITests {
 
     // Set the log level for App Check Core
     AppCheckCoreLogger.logLevel = .debug
+
+    // MARK: - GACAppCheckErrors
+
+    let code: AppCheckCoreMessageCode = .loggerAppCheckMessageCodeAppAttestNotSupported
+    switch code {
+    case .loggerAppCheckMessageCodeUnknown: break
+    case .loggerAppCheckMessageCodeProviderIsMissing: break
+    case .loggerAppCheckMessageCodeUnexpectedHTTPCode: break
+    case .loggerAppCheckMessageLocalDebugToken: break
+    case .loggerAppCheckMessageEnvironmentVariableDebugToken: break
+    case .loggerAppCheckMessageDebugProviderFirebaseEnvironmentVariable: break
+    case .loggerAppCheckMessageDebugProviderFailedExchange: break
+    case .loggerAppCheckMessageCodeAppAttestNotSupported: break
+    case .loggerAppCheckMessageCodeAttestationRejected: break
+    case .loggerAppCheckMessageCodeAssertionRejected: break
+    @unknown default: break
+    }
   }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 11.1.0
+- [changed] Fall back to App Attest attestation phase if assertion phase fails
+  with DeviceCheck error.
+
 # 11.0.1 (SwiftPM Only)
 - [changed] Lowered the minimum supported Mac Catalyst version to 13.0.
   This aligns with the minimum supported Mac Catalyst version for the


### PR DESCRIPTION
There are two flows for App Attest: attestation and then assertion. Up until this PR, there was no retry mechanism for the assertion flow. This PR adds behavior to fall back to the attestation phase in the event an assertion cannot be generated by Apple's DeviceCheck framework using the prior attestation artifacts. 

Not addressed – changing where some attestation artifacts are stored (currently in user defaults). This is not ideal as the artifact may survive device migration and backup. That being said, such an issue should surface during the assertion flow, which should, with this PR, now fall back to the attestation flow (which is what we would need to do anyway if the artifact could not be found).

Note, I think the split diff is easier to use when reviewing.