### PR TITLE
[AppCheckCore] Skip local cache when making network requests

### DIFF
--- a/AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.m
+++ b/AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.m
@@ -91,6 +91,7 @@ static NSString *const kDefaultBaseURL = @"https://firebaseappcheck.googleapis.c
              __block NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:requestURL];
              request.HTTPMethod = HTTPMethod;
              request.HTTPBody = body;
+             request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
 
              if (self.APIKey) {
                [request setValue:self.APIKey forHTTPHeaderField:kAPIKeyHeaderKey];

--- a/AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.m
+++ b/AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.m
@@ -91,6 +91,8 @@ static NSString *const kDefaultBaseURL = @"https://firebaseappcheck.googleapis.c
              __block NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:requestURL];
              request.HTTPMethod = HTTPMethod;
              request.HTTPBody = body;
+             // App Check should ignore cached data to prevent reusing
+             // previously received artifacts (e.g. App Attest challenge).
              request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
 
              if (self.APIKey) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 11.2.0
+- [changed] To prevent reusing expired artifacts, skip local cache when making
+  network requests.
+
 # 11.1.0
 - [changed] Fall back to App Attest attestation phase if assertion phase fails
   with DeviceCheck error.


### PR DESCRIPTION
All of the URL sessions within used App Check are [ephemeral](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1410529-ephemeralsessionconfiguration?language=objc). While they don't write a cache to disk, they do persist one to RAM. Cache policy can be controlled at the `NSURLRequest` level, and by [default](https://developer.apple.com/documentation/foundation/nsurlrequestcachepolicy/nsurlrequestuseprotocolcachepolicy?language=objc), the cache may be read from in some scenarios.

The SDK is intentional about making requests and hitting the cache may cause successive requests to send outdated artifacts. Therefore, we should try setting the cache policy to skip the local cache.

