### PR TITLE
[CI] Update macOS / Xcode versions for pod_lib_lint

### DIFF
--- a/.github/workflows/app_check_core.yml
+++ b/.github/workflows/app_check_core.yml
@@ -16,12 +16,14 @@ jobs:
       matrix:
         # TODO: macos tests are blocked by https://github.com/erikdoe/ocmock/pull/532
         target: [ios, tvos, macos --skip-tests, watchos]
-        os: [macos-12, macos-13]
+        os: [macos-13, macos-14, macos-15]
         include:
-          - os: macos-12
-            xcode: Xcode_14.2
           - os: macos-13
-            xcode: Xcode_15.0.1
+            xcode: Xcode_15.2
+          - os: macos-14
+            xcode: Xcode_15.4
+          - os: macos-15
+            xcode: Xcode_16.1
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Removed macOS 12 + Xcode 14.2 from the test matrix since the macOS 12 runner images are [deprecated](https://github.com/actions/runner-images/issues/10721). Although Xcode 15.2 is available on both macOS 13 and 14, I kept `macos-13` in the test matrix for `x86_64` coverage (`macos-14` and `macos-15` are both `arm64`).