### PR TITLE
[Infra] Upgrade to `clang-format@20`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,8 @@ name: check
 on:
   pull_request:
   push:
-    branches: main
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -30,7 +31,7 @@ jobs:
     - name: Setup check
       run: |
         brew update
-        brew install clang-format@19
+        brew install clang-format@20
         brew install mint
         mint bootstrap
 


### PR DESCRIPTION
- Upgrade `clang-format` to v20 since v19 is no longer available on Homebrew.
- Fixed `branches` format in `check` workflow
  - `Incorrect type. Expected "array". yaml-schema: GitHub Workflow`


#no-changelog