### PR TITLE
Add a retry for 401 errors

### DIFF
--- a/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -419,7 +419,8 @@ NS_ASSUME_NONNULL_BEGIN
         // error.
         GACAppCheckHTTPError *HTTPError = (GACAppCheckHTTPError *)error;
         if ([HTTPError isKindOfClass:[GACAppCheckHTTPError class]] &&
-            HTTPError.HTTPResponse.statusCode == 403) {
+            (HTTPError.HTTPResponse.statusCode == 401 ||
+             HTTPError.HTTPResponse.statusCode == 403)) {
           GACAppCheckLogDebug(GACLoggerAppCheckMessageCodeAttestationRejected,
                               @"App Attest attestation was rejected by backend. The existing "
                               @"attestation will be reset.");

--- a/AppCheckCore/Sources/Core/Backoff/GACAppCheckBackoffWrapper.m
+++ b/AppCheckCore/Sources/Core/Backoff/GACAppCheckBackoffWrapper.m
@@ -261,7 +261,7 @@ static double const kMaxExponentialBackoffInterval = 4 * 60 * 60;  // 4 hours.
       return GACAppCheckBackoffType1Day;
     }
 
-    if (statusCode == 403) {
+    if (statusCode == 401 || statusCode == 403) {
       // Project may have been soft-deleted accidentally. There is a chance of timely recovery, so
       // try again later.
       return GACAppCheckBackoffTypeExponential;

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckBackoffWrapperTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckBackoffWrapperTests.m
@@ -262,6 +262,9 @@
   GACAppCheckHTTPError *HTTP400Error = [self httpErrorWithStatusCode:400];
   XCTAssertEqual(errorHandler(HTTP400Error), GACAppCheckBackoffType1Day);
 
+  GACAppCheckHTTPError *HTTP401Error = [self httpErrorWithStatusCode:401];
+  XCTAssertEqual(errorHandler(HTTP401Error), GACAppCheckBackoffTypeExponential);
+
   GACAppCheckHTTPError *HTTP403Error = [self httpErrorWithStatusCode:403];
   XCTAssertEqual(errorHandler(HTTP403Error), GACAppCheckBackoffTypeExponential);
 
@@ -276,7 +279,7 @@
 
   // Test all other codes from 400 to 599.
   for (NSInteger statusCode = 400; statusCode < 600; statusCode++) {
-    if (statusCode == 400 || statusCode == 404) {
+    if (statusCode == 400 || statusCode == 401 || statusCode == 404) {
       // Skip status codes with non-exponential backoff.
       continue;
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 11.3.0
+- [changed] Add a retry for 401 failures. (https://github.com/firebase/firebase-ios-sdk/issues/15372)
+
 # 11.2.0
 - [changed] To prevent reusing expired artifacts, skip local cache when making
   network requests.


### PR DESCRIPTION
Fix https://github.com/firebase/firebase-ios-sdk/issues/15372

Do the same retry logic for 401 errors that we do for 403 errors.

Gemini's summary:

✦ This PR introduces enhanced error handling for Firebase App Check by configuring the SDK to retry requests upon receiving a 401 Unauthorized HTTP status code.

  Problem: Previously, 401 Unauthorized errors from the App Check backend were not treated as retryable conditions. This meant that if an App Check token became invalid or expired, the SDK would not attempt to fetch a new one with backoff, potentially leading to immediate failures in the client application.

  Solution:
   * The GACAppCheckBackoffWrapper's error handler has been updated to classify 401 Unauthorized responses alongside 403 Forbidden errors, triggering an exponential backoff strategy.
   * The GACAppAttestProvider's attestation rejection logic now also explicitly handles 401 errors, ensuring that the attestation process is reset and retried, similar to how 403 errors are managed.

  Impact: This change improves the resilience of the App Check SDK by enabling it to gracefully recover from transient authentication issues, providing a more robust and seamless experience for end-users.

  Testing:
   * New unit tests in GACAppCheckBackoffWrapperTests.m confirm that 401 errors correctly trigger the exponential backoff mechanism.
   * GACAppAttestProviderTests.m includes a new test case (testGetToken_WhenAttestationIsRejectedWith401_ThenAttestationIsResetAndRetriedOnceSuccess) to specifically verify the complete attestation reset and retry flow for 401 errors.
   * Existing attestation rejection tests were refactored for improved readability and maintainability.
