### PR TITLE
fix: Reset and retry attestation on DCErrorUnknownSystemFailure during assertion phase

### DIFF
--- a/.github/workflows/app_check_core.yml
+++ b/.github/workflows/app_check_core.yml
@@ -24,8 +24,8 @@ jobs:
             xcode: Xcode_26.2
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Scripts Directory
       run: ./setup-scripts.sh
     - name: Setup Bundler
@@ -34,7 +34,7 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: contains(matrix.target, 'macos') == false
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -49,8 +49,8 @@ jobs:
   catalyst:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Scripts Directory
       run: ./setup-scripts.sh
     - name: Setup Bundler

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,10 +16,10 @@ jobs:
     env:
       MINT_PATH: ${{ github.workspace }}/mint
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
     - name: Cache Mint packages
-      uses: actions/cache@v3
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
       with:
         path: ${{ env.MINT_PATH }}
         key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -23,8 +23,8 @@ jobs:
             platform: iOS
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Scripts Directory
       run: ./setup-scripts.sh
     - name: Xcode

--- a/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -375,34 +375,31 @@ NS_ASSUME_NONNULL_BEGIN
 
                 return [self attestKey:keyID challenge:challenge];
               })
-      .recoverOn(
-          self.queue,
-          ^id(NSError *error) {
-            // If Apple rejected the key (DCErrorInvalidKey or
-            // DCErrorInvalidInput) then reset the attestation and
-            // throw a specific error to signal retry (GACAppAttestRejectionError).
-            NSError *underlyingError = error.userInfo[NSUnderlyingErrorKey];
-            if (underlyingError && [underlyingError.domain isEqualToString:DCErrorDomain] &&
-                (underlyingError.code == DCErrorInvalidKey ||
-                 underlyingError.code == DCErrorInvalidInput ||
-                 underlyingError.code == DCErrorUnknownSystemFailure)) {
-              NSString *logMessage = [NSString
-                  stringWithFormat:
-                      @"App Attest invalid key/input/system failure; the existing attestation "
-                      @"will be reset. DC Error Code: %@.",
-                      @(underlyingError.code)];
-              GACAppCheckLog(GACLoggerAppCheckMessageCodeAttestationRejected,
-                             GACAppCheckLogLevelDebug, logMessage);
-              // Reset the attestation.
-              return [self resetAttestation].thenOn(self.queue, ^NSError *(id result) {
-                // Throw the rejection error.
-                return [[GACAppAttestRejectionError alloc] initWithUnderlyingError:error];
-              });
-            }
+      .recoverOn(self.queue,
+                 ^id(NSError *error) {
+                   // If Apple rejected the key (DCErrorInvalidKey or
+                   // DCErrorInvalidInput) then reset the attestation and
+                   // throw a specific error to signal retry (GACAppAttestRejectionError).
+                   NSError *underlyingError = error.userInfo[NSUnderlyingErrorKey];
+                   if (underlyingError && [underlyingError.domain isEqualToString:DCErrorDomain] &&
+                       (underlyingError.code == DCErrorInvalidKey ||
+                        underlyingError.code == DCErrorInvalidInput)) {
+                     NSString *logMessage = [NSString
+                         stringWithFormat:@"App Attest invalid key/input; the existing attestation "
+                                          @"will be reset. DC Error Code: %@.",
+                                          @(underlyingError.code)];
+                     GACAppCheckLog(GACLoggerAppCheckMessageCodeAttestationRejected,
+                                    GACAppCheckLogLevelDebug, logMessage);
+                     // Reset the attestation.
+                     return [self resetAttestation].thenOn(self.queue, ^NSError *(id result) {
+                       // Throw the rejection error.
+                       return [[GACAppAttestRejectionError alloc] initWithUnderlyingError:error];
+                     });
+                   }
 
-            // Otherwise just re-throw the error.
-            return error;
-          })
+                   // Otherwise just re-throw the error.
+                   return error;
+                 })
       .thenOn(self.queue,
               ^FBLPromise<NSArray *> *(GACAppAttestKeyAttestationResult *result) {
                 // 3. Exchange the attestation to FAC token and pass the results to the next step.

--- a/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -375,32 +375,34 @@ NS_ASSUME_NONNULL_BEGIN
 
                 return [self attestKey:keyID challenge:challenge];
               })
-      .recoverOn(self.queue,
-                 ^id(NSError *error) {
-                   // If Apple rejected the key (DCErrorInvalidKey or
-                   // DCErrorInvalidInput) then reset the attestation and
-                   // throw a specific error to signal retry (GACAppAttestRejectionError).
-                   NSError *underlyingError = error.userInfo[NSUnderlyingErrorKey];
-                   if (underlyingError && [underlyingError.domain isEqualToString:DCErrorDomain] &&
-                       (underlyingError.code == DCErrorInvalidKey ||
-                        underlyingError.code == DCErrorInvalidInput ||
-                        underlyingError.code == DCErrorUnknownSystemFailure)) {
-                     NSString *logMessage = [NSString
-                         stringWithFormat:@"App Attest invalid key/input/system failure; the existing attestation "
-                                          @"will be reset. DC Error Code: %@.",
-                                          @(underlyingError.code)];
-                     GACAppCheckLog(GACLoggerAppCheckMessageCodeAttestationRejected,
-                                    GACAppCheckLogLevelDebug, logMessage);
-                     // Reset the attestation.
-                     return [self resetAttestation].thenOn(self.queue, ^NSError *(id result) {
-                       // Throw the rejection error.
-                       return [[GACAppAttestRejectionError alloc] initWithUnderlyingError:error];
-                     });
-                   }
+      .recoverOn(
+          self.queue,
+          ^id(NSError *error) {
+            // If Apple rejected the key (DCErrorInvalidKey or
+            // DCErrorInvalidInput) then reset the attestation and
+            // throw a specific error to signal retry (GACAppAttestRejectionError).
+            NSError *underlyingError = error.userInfo[NSUnderlyingErrorKey];
+            if (underlyingError && [underlyingError.domain isEqualToString:DCErrorDomain] &&
+                (underlyingError.code == DCErrorInvalidKey ||
+                 underlyingError.code == DCErrorInvalidInput ||
+                 underlyingError.code == DCErrorUnknownSystemFailure)) {
+              NSString *logMessage = [NSString
+                  stringWithFormat:
+                      @"App Attest invalid key/input/system failure; the existing attestation "
+                      @"will be reset. DC Error Code: %@.",
+                      @(underlyingError.code)];
+              GACAppCheckLog(GACLoggerAppCheckMessageCodeAttestationRejected,
+                             GACAppCheckLogLevelDebug, logMessage);
+              // Reset the attestation.
+              return [self resetAttestation].thenOn(self.queue, ^NSError *(id result) {
+                // Throw the rejection error.
+                return [[GACAppAttestRejectionError alloc] initWithUnderlyingError:error];
+              });
+            }
 
-                   // Otherwise just re-throw the error.
-                   return error;
-                 })
+            // Otherwise just re-throw the error.
+            return error;
+          })
       .thenOn(self.queue,
               ^FBLPromise<NSArray *> *(GACAppAttestKeyAttestationResult *result) {
                 // 3. Exchange the attestation to FAC token and pass the results to the next step.
@@ -478,48 +480,50 @@ NS_ASSUME_NONNULL_BEGIN
                     // 1.2. Get the statement SHA256 hash.
                     return [GACAppCheckCryptoUtils sha256HashFromData:[statementForAssertion copy]];
                   }]
-      .thenOn(
-          self.queue,
-          ^FBLPromise<NSData *> *(NSData *statementHash) {
-            // 2. Generate App Attest assertion.
-            return [FBLPromise onQueue:self.queue
-                       wrapObjectOrErrorCompletion:^(
-                           FBLPromiseObjectOrErrorCompletion _Nonnull handler) {
-                         [self.appAttestService generateAssertion:keyID
-                                                   clientDataHash:statementHash
-                                                completionHandler:handler];
-                       }]
-                .recoverOn(self.queue, ^id(NSError *appAttestError) {
-                  NSError *error = [_GACAppCheckErrorUtil
-                      appAttestGenerateAssertionFailedWithError:appAttestError
-                                                          keyId:keyID
-                                                 clientDataHash:statementHash];
+      .thenOn(self.queue,
+              ^FBLPromise<NSData *> *(NSData *statementHash) {
+                // 2. Generate App Attest assertion.
+                return [FBLPromise onQueue:self.queue
+                           wrapObjectOrErrorCompletion:^(
+                               FBLPromiseObjectOrErrorCompletion _Nonnull handler) {
+                             [self.appAttestService generateAssertion:keyID
+                                                       clientDataHash:statementHash
+                                                    completionHandler:handler];
+                           }]
+                    .recoverOn(self.queue, ^id(NSError *appAttestError) {
+                      NSError *error = [_GACAppCheckErrorUtil
+                          appAttestGenerateAssertionFailedWithError:appAttestError
+                                                              keyId:keyID
+                                                     clientDataHash:statementHash];
 
-                  // If Apple rejected the key (DCErrorInvalidKey,
-                  // DCErrorInvalidInput or DCErrorUnknownSystemFailure) then reset the
-                  // attestation and throw a specific error to signal retry (GACAppAttestRejectionError).
-                  NSError *underlyingError = error.userInfo[NSUnderlyingErrorKey];
-                  if (underlyingError && [underlyingError.domain isEqualToString:DCErrorDomain] &&
-                      (underlyingError.code == DCErrorInvalidKey ||
-                       underlyingError.code == DCErrorInvalidInput ||
-                       underlyingError.code == DCErrorUnknownSystemFailure)) {
-                    NSString *logMessage = [NSString
-                        stringWithFormat:@"App Attest invalid key/input/system failure; the existing attestation "
-                                         @"will be reset. DC Error Code: %@.",
-                                         @(underlyingError.code)];
-                    GACAppCheckLog(GACLoggerAppCheckMessageCodeAssertionRejected,
-                                   GACAppCheckLogLevelDebug, logMessage);
-                    // Reset the attestation.
-                    return [self resetAttestation].thenOn(self.queue, ^NSError *(id result) {
-                      // Throw the rejection error.
-                      return [[GACAppAttestRejectionError alloc] initWithUnderlyingError:error];
+                      // If Apple rejected the key (DCErrorInvalidKey,
+                      // DCErrorInvalidInput or DCErrorUnknownSystemFailure) then reset the
+                      // attestation and throw a specific error to signal retry
+                      // (GACAppAttestRejectionError).
+                      NSError *underlyingError = error.userInfo[NSUnderlyingErrorKey];
+                      if (underlyingError &&
+                          [underlyingError.domain isEqualToString:DCErrorDomain] &&
+                          (underlyingError.code == DCErrorInvalidKey ||
+                           underlyingError.code == DCErrorInvalidInput ||
+                           underlyingError.code == DCErrorUnknownSystemFailure)) {
+                        NSString *logMessage =
+                            [NSString stringWithFormat:@"App Attest invalid key/input/system "
+                                                       @"failure; the existing attestation "
+                                                       @"will be reset. DC Error Code: %@.",
+                                                       @(underlyingError.code)];
+                        GACAppCheckLog(GACLoggerAppCheckMessageCodeAssertionRejected,
+                                       GACAppCheckLogLevelDebug, logMessage);
+                        // Reset the attestation.
+                        return [self resetAttestation].thenOn(self.queue, ^NSError *(id result) {
+                          // Throw the rejection error.
+                          return [[GACAppAttestRejectionError alloc] initWithUnderlyingError:error];
+                        });
+                      }
+
+                      // Otherwise just re-throw the error.
+                      return error;
                     });
-                  }
-
-                  // Otherwise just re-throw the error.
-                  return error;
-                });
-          })
+              })
       // 3. Compose the result object.
       .thenOn(self.queue, ^GACAppAttestAssertionData *(NSData *assertion) {
         return [[GACAppAttestAssertionData alloc] initWithChallenge:challenge

--- a/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -383,9 +383,10 @@ NS_ASSUME_NONNULL_BEGIN
                    NSError *underlyingError = error.userInfo[NSUnderlyingErrorKey];
                    if (underlyingError && [underlyingError.domain isEqualToString:DCErrorDomain] &&
                        (underlyingError.code == DCErrorInvalidKey ||
-                        underlyingError.code == DCErrorInvalidInput)) {
+                        underlyingError.code == DCErrorInvalidInput ||
+                        underlyingError.code == DCErrorUnknownSystemFailure)) {
                      NSString *logMessage = [NSString
-                         stringWithFormat:@"App Attest invalid key/input; the existing attestation "
+                         stringWithFormat:@"App Attest invalid key/input/system failure; the existing attestation "
                                           @"will be reset. DC Error Code: %@.",
                                           @(underlyingError.code)];
                      GACAppCheckLog(GACLoggerAppCheckMessageCodeAttestationRejected,
@@ -494,15 +495,16 @@ NS_ASSUME_NONNULL_BEGIN
                                                           keyId:keyID
                                                  clientDataHash:statementHash];
 
-                  // If Apple rejected the key (DCErrorInvalidKey or
-                  // DCErrorInvalidInput) then reset the attestation and
-                  // throw a specific error to signal retry (GACAppAttestRejectionError).
+                  // If Apple rejected the key (DCErrorInvalidKey,
+                  // DCErrorInvalidInput or DCErrorUnknownSystemFailure) then reset the
+                  // attestation and throw a specific error to signal retry (GACAppAttestRejectionError).
                   NSError *underlyingError = error.userInfo[NSUnderlyingErrorKey];
                   if (underlyingError && [underlyingError.domain isEqualToString:DCErrorDomain] &&
                       (underlyingError.code == DCErrorInvalidKey ||
-                       underlyingError.code == DCErrorInvalidInput)) {
+                       underlyingError.code == DCErrorInvalidInput ||
+                       underlyingError.code == DCErrorUnknownSystemFailure)) {
                     NSString *logMessage = [NSString
-                        stringWithFormat:@"App Attest invalid key/input; the existing attestation "
+                        stringWithFormat:@"App Attest invalid key/input/system failure; the existing attestation "
                                          @"will be reset. DC Error Code: %@.",
                                          @(underlyingError.code)];
                     GACAppCheckLog(GACLoggerAppCheckMessageCodeAssertionRejected,

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
@@ -569,6 +569,11 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
                                                userInfo:nil];
   [self assertAttestationResetAndGetTokenRetryWhenExistingKeyIsRejectedWithAttestationError:
             invalidInputError];
+  NSError *systemFailureError = [NSError errorWithDomain:DCErrorDomain
+                                                    code:DCErrorUnknownSystemFailure
+                                                userInfo:nil];
+  [self assertAttestationResetAndGetTokenRetryWhenExistingKeyIsRejectedWithAttestationError:
+            systemFailureError];
 }
 
 #pragma mark - FAC token refresh (assertion)
@@ -755,6 +760,11 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
                                                userInfo:nil];
   [self assertAttestationResetAndGetTokenRetryWhenExistingKeyIsRejectedWithAssertionError:
             invalidInputError];
+  NSError *systemFailureError = [NSError errorWithDomain:DCErrorDomain
+                                                    code:DCErrorUnknownSystemFailure
+                                                userInfo:nil];
+  [self assertAttestationResetAndGetTokenRetryWhenExistingKeyIsRejectedWithAssertionError:
+            systemFailureError];
 }
 
 #pragma mark - Request merging

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
@@ -569,11 +569,6 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
                                                userInfo:nil];
   [self assertAttestationResetAndGetTokenRetryWhenExistingKeyIsRejectedWithAttestationError:
             invalidInputError];
-  NSError *systemFailureError = [NSError errorWithDomain:DCErrorDomain
-                                                    code:DCErrorUnknownSystemFailure
-                                                userInfo:nil];
-  [self assertAttestationResetAndGetTokenRetryWhenExistingKeyIsRejectedWithAttestationError:
-            systemFailureError];
 }
 
 #pragma mark - FAC token refresh (assertion)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- [fixed] Added recovery logic to reset and retry attestation when App Attest
+  returns `DCErrorUnknownSystemFailure` during key attestation or assertion
+  generation. (https://github.com/firebase/firebase-ios-sdk/issues/16256)
+
 # 11.3.0
 - [changed] Added Recaptcha Enterprise attestation provider. (#94)
 - [changed] Only log local debug tokens when not yet registered. (#95)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - [fixed] Added recovery logic to reset and retry attestation when App Attest
-  returns `DCErrorUnknownSystemFailure` during key attestation or assertion
+  returns `DCErrorUnknownSystemFailure` during assertion
   generation. (https://github.com/firebase/firebase-ios-sdk/issues/16256)
 
 # 11.3.0


### PR DESCRIPTION
Note to reviewers: Review the first commit. the Second commit is whitespace changes to make style happy.

Address https://github.com/firebase/firebase-ios-sdk/issues/16256

# GACAppAttestProvider.m

## Assertion Generation Flow
```objc
                  if (underlyingError && [underlyingError.domain isEqualToString:DCErrorDomain] &&
                      (underlyingError.code == DCErrorInvalidKey ||
                       underlyingError.code == DCErrorInvalidInput ||
                       underlyingError.code == DCErrorUnknownSystemFailure)) {
```
- **Rationale**: When using a stored, cached key to generate assertions, Apple can return DCErrorUnknownSystemFailure instead of DCErrorInvalidKey. To prevent unintended key-minting or failure loops during the initial attestation process, this error is only caught and handled during the assertion phase (e.g., inside getTokenWithLimitedUse). Deleting the invalid/corrupted cached credentials (via resetAttestation) at this specific stage and returning GACAppAttestRejectionError triggers a retry which generates a new key pair, safely recovering the user from the permanent lockout loop.
- **Robustness**: Since the token fetch promise queue allows exactly one retry attempt per request, any persistent system failure will not loop infinitely; it will propagate the error after the second attempt.

---

# Test Coverage

## GACAppAttestProviderTests.m

- **Test cases added**:
  - `testGetToken_WhenAssertionIsRejectedByApple_ThenResetToAttestationAndRetryOnceSuccess` now runs validation for `DCErrorUnknownSystemFailure`.
- **Status**: Verified that all tests build and pass successfully.
