### PR TITLE
test(recaptcha): add coverage for invalid URL configuration

### DIFF
--- a/AppCheckRecaptchaProvider/Tests/RecaptchaAPIServiceTests.swift
+++ b/AppCheckRecaptchaProvider/Tests/RecaptchaAPIServiceTests.swift
@@ -134,4 +134,26 @@ final class RecaptchaAPIServiceTests: XCTestCase {
 
     waitForExpectations(timeout: 1.0)
   }
+
+  func testAppCheckTokenInvalidURL() {
+    mockCoreAPIService.baseURL = "not a scheme://test.com"
+    let apiService = RecaptchaAPIService(
+      apiService: mockCoreAPIService,
+      resourceName: "invalid_resource_name"
+    )
+
+    let expectation = self.expectation(description: "Token exchange fails with invalid URL")
+
+    apiService.appCheckToken(with: testRecaptchaToken, limitedUse: false).then { token in
+      XCTFail("Should not succeed with invalid URL")
+    }.catch { error in
+      XCTAssertEqual((error as NSError).domain, AppCheckCoreErrorDomain)
+      let expectedFailureReason =
+        "Invalid URL string: not a scheme://test.com/invalid_resource_name:exchangeRecaptchaEnterpriseToken"
+      XCTAssertEqual((error as NSError).localizedFailureReason, expectedFailureReason)
+      expectation.fulfill()
+    }
+
+    waitForExpectations(timeout: 1.0)
+  }
 }


### PR DESCRIPTION
**Description**
Adds test coverage for the invalid URL failure path in `RecaptchaAPIService`. 

This improvement was recommended by an analyzer during copybara.

If the SDK is initialized with a malformed base URL or resource name that fails `URL(string:)` parsing, it correctly rejects the token promise with an explicit "Invalid URL string" error. This test ensures we don't accidentally regress this behavior into a hard crash or silent failure in the future.

**Changes**
* Added `testAppCheckTokenInvalidURL` to `RecaptchaAPIServiceTests.swift`.
* Uses strict string matching (`XCTAssertEqual`) against the expected error message to prevent false positives.

**Verification**
- [x] Passed local unit tests.