### PR TITLE
fix: eliminate thread starvation flake in legacy provider tests

### DIFF
--- a/AppCheckCore/Sources/DebugProvider/API/GACAppCheckDebugProviderAPIService.m
+++ b/AppCheckCore/Sources/DebugProvider/API/GACAppCheckDebugProviderAPIService.m
@@ -86,27 +86,19 @@ static NSString *const kLimitedUseField = @"limited_use";
     return rejectedPromise;
   }
 
-  return [FBLPromise onQueue:[self backgroundQueue]
-                          do:^id _Nullable {
-                            NSError *encodingError;
-                            NSData *payloadJSON =
-                                [NSJSONSerialization dataWithJSONObject:@{
-                                  kDebugTokenField : debugToken,
-                                  kLimitedUseField : @(limitedUse)
-                                }
-                                                                options:0
-                                                                  error:&encodingError];
+  NSError *encodingError;
+  NSData *payloadJSON = [NSJSONSerialization
+      dataWithJSONObject:@{kDebugTokenField : debugToken, kLimitedUseField : @(limitedUse)}
+                 options:0
+                   error:&encodingError];
 
-                            if (payloadJSON != nil) {
-                              return payloadJSON;
-                            } else {
-                              return [_GACAppCheckErrorUtil JSONSerializationError:encodingError];
-                            }
-                          }];
-}
-
-- (dispatch_queue_t)backgroundQueue {
-  return dispatch_get_global_queue(QOS_CLASS_UTILITY, 0);
+  FBLPromise<NSData *> *payloadPromise = [FBLPromise pendingPromise];
+  if (payloadJSON != nil) {
+    [payloadPromise fulfill:payloadJSON];
+  } else {
+    [payloadPromise reject:[_GACAppCheckErrorUtil JSONSerializationError:encodingError]];
+  }
+  return payloadPromise;
 }
 
 @end

--- a/AppCheckCore/Sources/DeviceCheckProvider/API/GACDeviceCheckAPIService.m
+++ b/AppCheckCore/Sources/DeviceCheckProvider/API/GACDeviceCheckAPIService.m
@@ -84,29 +84,21 @@ static NSString *const kLimitedUseField = @"limited_use";
     return rejectedPromise;
   }
 
-  return [FBLPromise
-      onQueue:[self backgroundQueue]
-           do:^id _Nullable {
-             NSString *base64EncodedToken = [deviceToken base64EncodedStringWithOptions:0];
+  NSString *base64EncodedToken = [deviceToken base64EncodedStringWithOptions:0];
 
-             NSError *encodingError;
-             NSData *payloadJSON = [NSJSONSerialization dataWithJSONObject:@{
-               kDeviceTokenField : base64EncodedToken,
-               kLimitedUseField : @(limitedUse)
-             }
-                                                                   options:0
-                                                                     error:&encodingError];
+  NSError *encodingError;
+  NSData *payloadJSON = [NSJSONSerialization
+      dataWithJSONObject:@{kDeviceTokenField : base64EncodedToken, kLimitedUseField : @(limitedUse)}
+                 options:0
+                   error:&encodingError];
 
-             if (payloadJSON != nil) {
-               return payloadJSON;
-             } else {
-               return [_GACAppCheckErrorUtil JSONSerializationError:encodingError];
-             }
-           }];
-}
-
-- (dispatch_queue_t)backgroundQueue {
-  return dispatch_get_global_queue(QOS_CLASS_UTILITY, 0);
+  FBLPromise<NSData *> *payloadPromise = [FBLPromise pendingPromise];
+  if (payloadJSON != nil) {
+    [payloadPromise fulfill:payloadJSON];
+  } else {
+    [payloadPromise reject:[_GACAppCheckErrorUtil JSONSerializationError:encodingError]];
+  }
+  return payloadPromise;
 }
 
 @end


### PR DESCRIPTION
https://github.com/google/app-check/pull/100/changes?w=1

This PR resolves a persistent CI flake (a 1-second timeout failure) in the `DebugProvider` and `DeviceCheckProvider` test suites.

By removing an unnecessary background thread dispatch (`dispatch_get_global_queue`) and running trivial JSON serialization synchronously, we eliminate the risk of thread starvation on heavily loaded CI runners. This guarantees the tests execute within the timeout window and provides a micro-optimization to the SDK's execution path.

Addresses convo in https://github.com/google/app-check/pull/99#issuecomment-4753046632