### PR TITLE
ci: pin workflow actions to SHAs and bump to Node 24 runtimes

### DIFF
--- a/.github/workflows/app_check_core.yml
+++ b/.github/workflows/app_check_core.yml
@@ -24,8 +24,8 @@ jobs:
             xcode: Xcode_26.2
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+    - uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
     - name: Setup Scripts Directory
       run: ./setup-scripts.sh
     - name: Setup Bundler
@@ -49,8 +49,8 @@ jobs:
   catalyst:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+    - uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
     - name: Setup Scripts Directory
       run: ./setup-scripts.sh
     - name: Setup Bundler

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,10 +16,10 @@ jobs:
     env:
       MINT_PATH: ${{ github.workspace }}/mint
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
     - name: Cache Mint packages
-      uses: actions/cache@v3
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ env.MINT_PATH }}
         key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -23,8 +23,8 @@ jobs:
             platform: iOS
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+    - uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
     - name: Setup Scripts Directory
       run: ./setup-scripts.sh
     - name: Xcode


### PR DESCRIPTION
Addresses CI warnings about deprecated Node.js 20 actions, and pins action dependencies to full commit SHAs instead of moving version tags.

- actions/checkout: v3 -> v5.0.1 (Node 24)
- actions/cache: v3 -> v5.0.5 (Node 24)
- ruby/setup-ruby: v1 -> v1.99.0