### PR TITLE
fix: Only reset App Attest on DCErrorUnknownSystemFailure during assertion phase

### DIFF
--- a/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -391,15 +391,15 @@ NS_ASSUME_NONNULL_BEGIN
                      GACAppCheckLog(GACLoggerAppCheckMessageCodeAttestationRejected,
                                     GACAppCheckLogLevelDebug, logMessage);
                      // Reset the attestation.
-              return [self resetAttestation].thenOn(self.queue, ^NSError *(id result) {
-                // Throw the rejection error.
-                return [[GACAppAttestRejectionError alloc] initWithUnderlyingError:error];
-              });
-            }
+                     return [self resetAttestation].thenOn(self.queue, ^NSError *(id result) {
+                       // Throw the rejection error.
+                       return [[GACAppAttestRejectionError alloc] initWithUnderlyingError:error];
+                     });
+                   }
 
-            // Otherwise just re-throw the error.
-            return error;
-          })
+                   // Otherwise just re-throw the error.
+                   return error;
+                 })
       .thenOn(self.queue,
               ^FBLPromise<NSArray *> *(GACAppAttestKeyAttestationResult *result) {
                 // 3. Exchange the attestation to FAC token and pass the results to the next step.

--- a/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -375,25 +375,22 @@ NS_ASSUME_NONNULL_BEGIN
 
                 return [self attestKey:keyID challenge:challenge];
               })
-      .recoverOn(
-          self.queue,
-          ^id(NSError *error) {
-            // If Apple rejected the key (DCErrorInvalidKey or
-            // DCErrorInvalidInput) then reset the attestation and
-            // throw a specific error to signal retry (GACAppAttestRejectionError).
-            NSError *underlyingError = error.userInfo[NSUnderlyingErrorKey];
-            if (underlyingError && [underlyingError.domain isEqualToString:DCErrorDomain] &&
-                (underlyingError.code == DCErrorInvalidKey ||
-                 underlyingError.code == DCErrorInvalidInput ||
-                 underlyingError.code == DCErrorUnknownSystemFailure)) {
-              NSString *logMessage = [NSString
-                  stringWithFormat:
-                      @"App Attest invalid key/input/system failure; the existing attestation "
-                      @"will be reset. DC Error Code: %@.",
-                      @(underlyingError.code)];
-              GACAppCheckLog(GACLoggerAppCheckMessageCodeAttestationRejected,
-                             GACAppCheckLogLevelDebug, logMessage);
-              // Reset the attestation.
+      .recoverOn(self.queue,
+                 ^id(NSError *error) {
+                   // If Apple rejected the key (DCErrorInvalidKey or
+                   // DCErrorInvalidInput) then reset the attestation and
+                   // throw a specific error to signal retry (GACAppAttestRejectionError).
+                   NSError *underlyingError = error.userInfo[NSUnderlyingErrorKey];
+                   if (underlyingError && [underlyingError.domain isEqualToString:DCErrorDomain] &&
+                       (underlyingError.code == DCErrorInvalidKey ||
+                        underlyingError.code == DCErrorInvalidInput)) {
+                     NSString *logMessage = [NSString
+                         stringWithFormat:@"App Attest invalid key/input; the existing attestation "
+                                          @"will be reset. DC Error Code: %@.",
+                                          @(underlyingError.code)];
+                     GACAppCheckLog(GACLoggerAppCheckMessageCodeAttestationRejected,
+                                    GACAppCheckLogLevelDebug, logMessage);
+                     // Reset the attestation.
               return [self resetAttestation].thenOn(self.queue, ^NSError *(id result) {
                 // Throw the rejection error.
                 return [[GACAppAttestRejectionError alloc] initWithUnderlyingError:error];

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
@@ -569,11 +569,6 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
                                                userInfo:nil];
   [self assertAttestationResetAndGetTokenRetryWhenExistingKeyIsRejectedWithAttestationError:
             invalidInputError];
-  NSError *systemFailureError = [NSError errorWithDomain:DCErrorDomain
-                                                    code:DCErrorUnknownSystemFailure
-                                                userInfo:nil];
-  [self assertAttestationResetAndGetTokenRetryWhenExistingKeyIsRejectedWithAttestationError:
-            systemFailureError];
 }
 
 #pragma mark - FAC token refresh (assertion)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - [fixed] Added recovery logic to reset and retry attestation when App Attest
-  returns `DCErrorUnknownSystemFailure` during key attestation or assertion
+  returns `DCErrorUnknownSystemFailure` during assertion
   generation. (https://github.com/firebase/firebase-ios-sdk/issues/16256)
 
 # 11.3.0


### PR DESCRIPTION
With App Attest, there are two stages: attestation and assertion. Attestation involves creating a new key, which we need to minimize. Since the linked issue mentions the failure-loop is in the **assertion** phase, I think our reset signal should be more selective to only reset when the unknown failure is caught during the the assertion phase. The assertion phase locally and cryptographically creates an assertion, and does not involve minting a new key like the attestation phase.

https://github.com/google/app-check/pull/104/changes?w=1