### PR TITLE
fix(ci): add read permissions to github action workflows

### DIFF
--- a/.github/workflows/app_check_core.yml
+++ b/.github/workflows/app_check_core.yml
@@ -6,6 +6,9 @@ on:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -6,6 +6,9 @@ on:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Add `permissions: contents: read` block to the top level of the `app_check_core`, `check`, and `spm` workflows. This addresses CodeQL alerts regarding workflows not containing permissions and enforces the principle of least privilege by default.