### PR TITLE
fix: parse token exp claim for expiration clamp

### DIFF
--- a/AppCheckCore/Sources/Core/APIService/GACAppCheckToken+APIResponse.m
+++ b/AppCheckCore/Sources/Core/APIService/GACAppCheckToken+APIResponse.m
@@ -29,6 +29,46 @@ static NSString *const kResponseFieldTTL = @"ttl";
 
 @implementation GACAppCheckToken (APIResponse)
 
+static NSDate *GACAppCheckTokenExpirationDateFromJWT(NSString *token) {
+  NSArray<NSString *> *components = [token componentsSeparatedByString:@"."];
+  if (components.count != 3) {
+    return nil;
+  }
+
+  NSString *payloadBase64 = components[1];
+
+  // Convert base64url to base64
+  NSString *padded = [payloadBase64 stringByReplacingOccurrencesOfString:@"-" withString:@"+"];
+  padded = [padded stringByReplacingOccurrencesOfString:@"_" withString:@"/"];
+
+  NSUInteger paddingLength = padded.length % 4;
+  if (paddingLength > 0) {
+    padded = [padded stringByPaddingToLength:padded.length + (4 - paddingLength)
+                                  withString:@"="
+                             startingAtIndex:0];
+  }
+
+  NSData *payloadData = [[NSData alloc] initWithBase64EncodedString:padded options:0];
+  if (!payloadData) {
+    return nil;
+  }
+
+  NSDictionary *payloadDict = [NSJSONSerialization JSONObjectWithData:payloadData
+                                                              options:0
+                                                                error:nil];
+  if (![payloadDict isKindOfClass:[NSDictionary class]]) {
+    return nil;
+  }
+
+  NSNumber *expValue = payloadDict[@"exp"];
+  if (![expValue isKindOfClass:[NSNumber class]]) {
+    return nil;
+  }
+
+  NSTimeInterval exp = expValue.doubleValue;
+  return [NSDate dateWithTimeIntervalSince1970:exp];
+}
+
 - (nullable instancetype)initWithTokenExchangeResponse:(NSData *)response
                                            requestDate:(NSDate *)requestDate
                                                  error:(NSError **)outError {
@@ -64,7 +104,7 @@ static NSString *const kResponseFieldTTL = @"ttl";
   }
 
   NSString *timeToLiveString = responseDict[kResponseFieldTTL];
-  if (![token isKindOfClass:[NSString class]] || token.length <= 0) {
+  if (![timeToLiveString isKindOfClass:[NSString class]] || timeToLiveString.length <= 0) {
     GACAppCheckSetErrorToPointer(
         [_GACAppCheckErrorUtil appCheckTokenResponseErrorWithMissingField:kResponseFieldTTL],
         outError);
@@ -84,6 +124,10 @@ static NSString *const kResponseFieldTTL = @"ttl";
   }
 
   NSDate *expirationDate = [requestDate dateByAddingTimeInterval:secondsToLive];
+  NSDate *jwtExpirationDate = GACAppCheckTokenExpirationDateFromJWT(token);
+  if (jwtExpirationDate && [jwtExpirationDate compare:expirationDate] == NSOrderedAscending) {
+    expirationDate = jwtExpirationDate;
+  }
 
   return [self initWithToken:token expirationDate:expirationDate receivedAtDate:requestDate];
 }

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
@@ -388,6 +388,78 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
                                       precision:10]);
 }
 
+- (void)qtestAppCheckTokenWithAPIResponseValidJWTWithExp {
+  // 1. Prepare input parameters.
+  NSTimeInterval expTime = [[NSDate date] timeIntervalSince1970] + 500;
+  NSDictionary *payload = @{@"exp" : @(expTime)};
+  NSData *payloadData = [NSJSONSerialization dataWithJSONObject:payload options:0 error:nil];
+  NSString *payloadBase64 = [payloadData base64EncodedStringWithOptions:0];
+  payloadBase64 = [payloadBase64 stringByReplacingOccurrencesOfString:@"+" withString:@"-"];
+  payloadBase64 = [payloadBase64 stringByReplacingOccurrencesOfString:@"/" withString:@"_"];
+  payloadBase64 = [payloadBase64 stringByReplacingOccurrencesOfString:@"=" withString:@""];
+
+  NSString *jwtToken = [NSString stringWithFormat:@"header.%@.signature", payloadBase64];
+  NSDictionary *responseDict = @{@"token" : jwtToken, @"ttl" : @"1800s"};
+  NSData *responseBody = [NSJSONSerialization dataWithJSONObject:responseDict options:0 error:nil];
+
+  NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:200];
+  _GACURLSessionDataResponse *APIResponse =
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
+
+  // 2. Expected result.
+  NSString *expectedFACToken = jwtToken;
+
+  // 3. Parse API response.
+  __auto_type tokenPromise = [self.APIService appCheckTokenWithAPIResponse:APIResponse];
+
+  // 4. Verify.
+  XCTAssert(FBLWaitForPromisesWithTimeout(1));
+
+  XCTAssertTrue(tokenPromise.isFulfilled);
+  XCTAssertNil(tokenPromise.error);
+
+  XCTAssertEqualObjects(tokenPromise.value.token, expectedFACToken);
+  XCTAssertTrue([GACDateTestUtils isDate:tokenPromise.value.expirationDate
+      approximatelyEqualCurrentPlusTimeInterval:500
+                                      precision:10]);
+}
+
+- (void)testAppCheckTokenWithAPIResponseValidJWTWithExpGreaterThenTTL {
+  // 1. Prepare input parameters.
+  NSTimeInterval expTime = [[NSDate date] timeIntervalSince1970] + 2000;
+  NSDictionary *payload = @{@"exp" : @(expTime)};
+  NSData *payloadData = [NSJSONSerialization dataWithJSONObject:payload options:0 error:nil];
+  NSString *payloadBase64 = [payloadData base64EncodedStringWithOptions:0];
+  payloadBase64 = [payloadBase64 stringByReplacingOccurrencesOfString:@"+" withString:@"-"];
+  payloadBase64 = [payloadBase64 stringByReplacingOccurrencesOfString:@"/" withString:@"_"];
+  payloadBase64 = [payloadBase64 stringByReplacingOccurrencesOfString:@"=" withString:@""];
+
+  NSString *jwtToken = [NSString stringWithFormat:@"header.%@.signature", payloadBase64];
+  NSDictionary *responseDict = @{@"token" : jwtToken, @"ttl" : @"1800s"};
+  NSData *responseBody = [NSJSONSerialization dataWithJSONObject:responseDict options:0 error:nil];
+
+  NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:200];
+  _GACURLSessionDataResponse *APIResponse =
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
+
+  // 2. Expected result.
+  NSString *expectedFACToken = jwtToken;
+
+  // 3. Parse API response.
+  __auto_type tokenPromise = [self.APIService appCheckTokenWithAPIResponse:APIResponse];
+
+  // 4. Verify.
+  XCTAssert(FBLWaitForPromisesWithTimeout(1));
+
+  XCTAssertTrue(tokenPromise.isFulfilled);
+  XCTAssertNil(tokenPromise.error);
+
+  XCTAssertEqualObjects(tokenPromise.value.token, expectedFACToken);
+  XCTAssertTrue([GACDateTestUtils isDate:tokenPromise.value.expirationDate
+      approximatelyEqualCurrentPlusTimeInterval:1800
+                                      precision:10]);
+}
+
 - (void)testAppCheckTokenWithAPIResponseInvalidFormat {
   // 1. Prepare input parameters.
   NSString *responseBodyString = @"Token verification failed.";

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
@@ -388,7 +388,7 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
                                       precision:10]);
 }
 
-- (void)qtestAppCheckTokenWithAPIResponseValidJWTWithExp {
+- (void)testAppCheckTokenWithAPIResponseValidJWTWithExp {
   // 1. Prepare input parameters.
   NSTimeInterval expTime = [[NSDate date] timeIntervalSince1970] + 500;
   NSDictionary *payload = @{@"exp" : @(expTime)};
@@ -424,7 +424,7 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
                                       precision:10]);
 }
 
-- (void)testAppCheckTokenWithAPIResponseValidJWTWithExpGreaterThenTTL {
+- (void)testAppCheckTokenWithAPIResponseValidJWTWithExpGreaterThanTTL {
   // 1. Prepare input parameters.
   NSTimeInterval expTime = [[NSDate date] timeIntervalSince1970] + 2000;
   NSDictionary *payload = @{@"exp" : @(expTime)};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- [fixed] Parse the token `exp` claim to correctly clamp the `expirationDate`
+  and avoid artificially extending cached token
+  lifetimes. (https://github.com/firebase/firebase-ios-sdk/issues/16573)
+
 # 11.3.1
 - [fixed] Added recovery logic to reset and retry attestation when App Attest
   returns `DCErrorUnknownSystemFailure` during assertion


### PR DESCRIPTION
## Description

[Fixes #16573](https://github.com/firebase/firebase-ios-sdk/issues/16573)

`AppCheckCore` previously derived a cached token's `expirationDate` from **the local time at which the client happens to process the HTTP response**, rather than from the token's own `exp` claim. Because every downstream validity decision reads only that locally-derived value, any delay between the App Check backend minting a token and the client executing the response handler is silently converted into extra apparent lifetime. This can cause the SDK to serve an already-expired token for up to a full TTL if the process is suspended or stalled between the token request and the response handling.

This PR addresses the issue by explicitly parsing the JSON Web Token (`exp` claim) from the App Check token payload returned by the server. 
It then computes `expirationDate = min(jwtExpirationDate, requestDate + ttl)` clamping it to the correct bounds.
If the token is a mock token or malformed, it gracefully falls back to the original `requestDate + ttl` logic.

### Changes 
- Extracts the JWT `exp` claim in `GACAppCheckTokenExpirationDateFromJWT`.
- Modifies `initWithResponseDict:` inside `GACAppCheckToken+APIResponse` to compute the clamped expiration date based on the extracted `exp`.
- Added unit tests to `GACAppCheckAPIServiceTests.m`: `testAppCheckTokenWithAPIResponseValidJWTWithExp` and `testAppCheckTokenWithAPIResponseValidJWTWithExpGreaterThenTTL` to verify correct `expirationDate` extraction and clamping behavior when a valid JWT payload is intercepted.
