### PR TITLE
fix: capture request date before network request to prevent clock skew/suspension bugs

### DIFF
--- a/AppCheckCore/Sources/AppAttestProvider/API/GACAppAttestAPIService.m
+++ b/AppCheckCore/Sources/AppAttestProvider/API/GACAppAttestAPIService.m
@@ -166,17 +166,17 @@ static NSString *const kHTTPMethodPost = @"POST";
                                               body:HTTPBody
                                  additionalHeaders:@{kContentTypeKey : kJSONContentType}];
       })
-      .thenOn(
-          [self backgroundQueue], ^id _Nullable(_GACURLSessionDataResponse *_Nullable URLResponse) {
-            NSError *error;
+      .thenOn([self backgroundQueue],
+              ^id _Nullable(_GACURLSessionDataResponse *_Nullable URLResponse) {
+                NSError *error;
 
-            __auto_type response =
-                [[GACAppAttestAttestationResponse alloc] initWithResponseData:URLResponse.HTTPBody
-                                                                  requestDate:URLResponse.requestDate
-                                                                        error:&error];
+                __auto_type response = [[GACAppAttestAttestationResponse alloc]
+                    initWithResponseData:URLResponse.HTTPBody
+                             requestDate:URLResponse.requestDate
+                                   error:&error];
 
-            return response ?: error;
-          });
+                return response ?: error;
+              });
 }
 
 #pragma mark - Request HTTP Body

--- a/AppCheckCore/Sources/AppAttestProvider/API/GACAppAttestAPIService.m
+++ b/AppCheckCore/Sources/AppAttestProvider/API/GACAppAttestAPIService.m
@@ -172,7 +172,7 @@ static NSString *const kHTTPMethodPost = @"POST";
 
             __auto_type response =
                 [[GACAppAttestAttestationResponse alloc] initWithResponseData:URLResponse.HTTPBody
-                                                                  requestDate:[NSDate date]
+                                                                  requestDate:URLResponse.requestDate
                                                                         error:&error];
 
             return response ?: error;

--- a/AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.m
+++ b/AppCheckCore/Sources/Core/APIService/GACAppCheckAPIService.m
@@ -196,7 +196,7 @@ static NSString *const kAppCheckUseStagingEnvKey = @"_AppCheckUseStaging";
 
                             GACAppCheckToken *token = [[GACAppCheckToken alloc]
                                 initWithTokenExchangeResponse:response.HTTPBody
-                                                  requestDate:[NSDate date]
+                                                  requestDate:response.requestDate
                                                         error:&error];
                             return token ?: error;
                           }];

--- a/AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.m
+++ b/AppCheckCore/Sources/Core/APIService/GACURLSessionDataResponse.m
@@ -18,11 +18,14 @@
 
 @implementation _GACURLSessionDataResponse
 
-- (instancetype)initWithResponse:(NSHTTPURLResponse *)response HTTPBody:(NSData *)body {
+- (instancetype)initWithResponse:(NSHTTPURLResponse *)response
+                        HTTPBody:(NSData *)body
+                     requestDate:(NSDate *)requestDate {
   self = [super init];
   if (self) {
     _HTTPResponse = response;
     _HTTPBody = body;
+    _requestDate = requestDate;
   }
   return self;
 }

--- a/AppCheckCore/Sources/Core/APIService/NSURLSession+GACPromises.m
+++ b/AppCheckCore/Sources/Core/APIService/NSURLSession+GACPromises.m
@@ -28,6 +28,7 @@
 
 - (FBLPromise<_GACURLSessionDataResponse *> *)gac_dataTaskPromiseWithRequest:
     (NSURLRequest *)URLRequest {
+  NSDate *requestDate = [NSDate date];
   return [FBLPromise async:^(FBLPromiseFulfillBlock fulfill, FBLPromiseRejectBlock reject) {
     [[self dataTaskWithRequest:URLRequest
              completionHandler:^(NSData *_Nullable data, NSURLResponse *_Nullable response,
@@ -37,7 +38,8 @@
                } else {
                  fulfill([[_GACURLSessionDataResponse alloc]
                      initWithResponse:(NSHTTPURLResponse *)response
-                             HTTPBody:data]);
+                             HTTPBody:data
+                          requestDate:requestDate]);
                }
              }] resume];
   }];

--- a/AppCheckCore/Sources/Public/AppCheckCore/_GACURLSessionDataResponse.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/_GACURLSessionDataResponse.h
@@ -26,8 +26,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, readonly) NSHTTPURLResponse *HTTPResponse;
 @property(nonatomic, nullable, readonly) NSData *HTTPBody;
+@property(nonatomic, readonly) NSDate *requestDate;
 
-- (instancetype)initWithResponse:(NSHTTPURLResponse *)response HTTPBody:(nullable NSData *)body;
+- (instancetype)initWithResponse:(NSHTTPURLResponse *)response
+                        HTTPBody:(nullable NSData *)body
+                     requestDate:(NSDate *)requestDate;
 
 @end
 

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestAPIServiceTests.m
@@ -534,7 +534,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   XCTAssertNotNil(responseBody);
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:code];
   _GACURLSessionDataResponse *APIResponse =
-      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody requestDate:[NSDate date]];
   return APIResponse;
 }
 

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestAPIServiceTests.m
@@ -534,7 +534,9 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
   XCTAssertNotNil(responseBody);
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:code];
   _GACURLSessionDataResponse *APIResponse =
-      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody requestDate:[NSDate date]];
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse
+                                                  HTTPBody:responseBody
+                                               requestDate:[NSDate date]];
   return APIResponse;
 }
 

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
@@ -390,6 +390,36 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
                                       precision:10]);
 }
 
+- (void)testAppCheckTokenWithAPIResponseUsesRequestDate {
+  // 1. Prepare input parameters.
+  NSData *responseBody =
+      [GACFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
+  XCTAssertNotNil(responseBody);
+  NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:200];
+  NSDate *requestDate = [NSDate dateWithTimeIntervalSince1970:100000];
+  _GACURLSessionDataResponse *APIResponse =
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse
+                                                  HTTPBody:responseBody
+                                               requestDate:requestDate];
+
+  // 2. Expected result.
+  NSString *expectedFACToken = @"valid_app_check_token";
+
+  // 3. Parse API response.
+  __auto_type tokenPromise = [self.APIService appCheckTokenWithAPIResponse:APIResponse];
+
+  // 4. Verify.
+  XCTAssert(FBLWaitForPromisesWithTimeout(1));
+
+  XCTAssertTrue(tokenPromise.isFulfilled);
+  XCTAssertNil(tokenPromise.error);
+
+  XCTAssertEqualObjects(tokenPromise.value.token, expectedFACToken);
+
+  NSDate *expectedExpiration = [requestDate dateByAddingTimeInterval:1800];
+  XCTAssertEqualObjects(tokenPromise.value.expirationDate, expectedExpiration);
+}
+
 - (void)testAppCheckTokenWithAPIResponseInvalidFormat {
   // 1. Prepare input parameters.
   NSString *responseBodyString = @"Token verification failed.";

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
@@ -368,7 +368,7 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   XCTAssertNotNil(responseBody);
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:200];
   _GACURLSessionDataResponse *APIResponse =
-      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody requestDate:[NSDate date]];
 
   // 2. Expected result.
   NSString *expectedFACToken = @"valid_app_check_token";
@@ -394,7 +394,7 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   NSData *responseBody = [responseBodyString dataUsingEncoding:NSUTF8StringEncoding];
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:200];
   _GACURLSessionDataResponse *APIResponse =
-      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody requestDate:[NSDate date]];
 
   // 2. Parse API response.
   __auto_type tokenPromise = [self.APIService appCheckTokenWithAPIResponse:APIResponse];
@@ -429,7 +429,7 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
 
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:200];
   _GACURLSessionDataResponse *APIResponse =
-      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:missingFiledBody];
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:missingFiledBody requestDate:[NSDate date]];
 
   // 2. Parse API response.
   __auto_type tokenPromise = [self.APIService appCheckTokenWithAPIResponse:APIResponse];
@@ -466,7 +466,7 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   FBLPromise<_GACURLSessionDataResponse *> *result = [FBLPromise pendingPromise];
   if (error == nil) {
     _GACURLSessionDataResponse *response =
-        [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:body];
+        [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:body requestDate:[NSDate date]];
     [result fulfill:response];
   } else {
     [result reject:error];

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
@@ -368,7 +368,9 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   XCTAssertNotNil(responseBody);
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:200];
   _GACURLSessionDataResponse *APIResponse =
-      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody requestDate:[NSDate date]];
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse
+                                                  HTTPBody:responseBody
+                                               requestDate:[NSDate date]];
 
   // 2. Expected result.
   NSString *expectedFACToken = @"valid_app_check_token";
@@ -394,7 +396,9 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   NSData *responseBody = [responseBodyString dataUsingEncoding:NSUTF8StringEncoding];
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:200];
   _GACURLSessionDataResponse *APIResponse =
-      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody requestDate:[NSDate date]];
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse
+                                                  HTTPBody:responseBody
+                                               requestDate:[NSDate date]];
 
   // 2. Parse API response.
   __auto_type tokenPromise = [self.APIService appCheckTokenWithAPIResponse:APIResponse];
@@ -429,7 +433,9 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
 
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:200];
   _GACURLSessionDataResponse *APIResponse =
-      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:missingFiledBody requestDate:[NSDate date]];
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse
+                                                  HTTPBody:missingFiledBody
+                                               requestDate:[NSDate date]];
 
   // 2. Parse API response.
   __auto_type tokenPromise = [self.APIService appCheckTokenWithAPIResponse:APIResponse];
@@ -466,7 +472,9 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   FBLPromise<_GACURLSessionDataResponse *> *result = [FBLPromise pendingPromise];
   if (error == nil) {
     _GACURLSessionDataResponse *response =
-        [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:body requestDate:[NSDate date]];
+        [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse
+                                                    HTTPBody:body
+                                                 requestDate:[NSDate date]];
     [result fulfill:response];
   } else {
     [result reject:error];

--- a/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderAPIServiceTests.m
@@ -77,7 +77,7 @@ static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_
   NSData *fakeResponseData = [@"fake response" dataUsingEncoding:NSUTF8StringEncoding];
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:200];
   _GACURLSessionDataResponse *APIResponse =
-      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:fakeResponseData];
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:fakeResponseData requestDate:[NSDate date]];
 
   self.mockAPIService.sendRequestPromise = [FBLPromise resolvedWith:APIResponse];
 
@@ -122,7 +122,7 @@ static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_
   NSData *fakeResponseData = [@"fake response" dataUsingEncoding:NSUTF8StringEncoding];
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:200];
   _GACURLSessionDataResponse *APIResponse =
-      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:fakeResponseData];
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:fakeResponseData requestDate:[NSDate date]];
 
   self.mockAPIService.sendRequestPromise = [FBLPromise resolvedWith:APIResponse];
 

--- a/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderAPIServiceTests.m
@@ -77,7 +77,9 @@ static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_
   NSData *fakeResponseData = [@"fake response" dataUsingEncoding:NSUTF8StringEncoding];
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:200];
   _GACURLSessionDataResponse *APIResponse =
-      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:fakeResponseData requestDate:[NSDate date]];
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse
+                                                  HTTPBody:fakeResponseData
+                                               requestDate:[NSDate date]];
 
   self.mockAPIService.sendRequestPromise = [FBLPromise resolvedWith:APIResponse];
 
@@ -122,7 +124,9 @@ static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_
   NSData *fakeResponseData = [@"fake response" dataUsingEncoding:NSUTF8StringEncoding];
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:200];
   _GACURLSessionDataResponse *APIResponse =
-      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:fakeResponseData requestDate:[NSDate date]];
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse
+                                                  HTTPBody:fakeResponseData
+                                               requestDate:[NSDate date]];
 
   self.mockAPIService.sendRequestPromise = [FBLPromise resolvedWith:APIResponse];
 

--- a/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
@@ -84,7 +84,9 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
 
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:200];
   _GACURLSessionDataResponse *APIResponse =
-      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody requestDate:[NSDate date]];
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse
+                                                  HTTPBody:responseBody
+                                               requestDate:[NSDate date]];
 
   self.mockAPIService.sendRequestPromise = [FBLPromise resolvedWith:APIResponse];
 
@@ -135,7 +137,9 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
 
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:200];
   _GACURLSessionDataResponse *APIResponse =
-      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody requestDate:[NSDate date]];
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse
+                                                  HTTPBody:responseBody
+                                               requestDate:[NSDate date]];
 
   self.mockAPIService.sendRequestPromise = [FBLPromise resolvedWith:APIResponse];
 

--- a/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
+++ b/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
@@ -84,7 +84,7 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
 
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:200];
   _GACURLSessionDataResponse *APIResponse =
-      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody requestDate:[NSDate date]];
 
   self.mockAPIService.sendRequestPromise = [FBLPromise resolvedWith:APIResponse];
 
@@ -135,7 +135,7 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
 
   NSHTTPURLResponse *HTTPResponse = [GACURLSessionFake HTTPResponseWithCode:200];
   _GACURLSessionDataResponse *APIResponse =
-      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
+      [[_GACURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody requestDate:[NSDate date]];
 
   self.mockAPIService.sendRequestPromise = [FBLPromise resolvedWith:APIResponse];
 

--- a/AppCheckRecaptchaProvider/Tests/MockRecaptchaSupport.swift
+++ b/AppCheckRecaptchaProvider/Tests/MockRecaptchaSupport.swift
@@ -110,7 +110,8 @@ class MockAppCheckCoreAPIService: NSObject, _GACAppCheckAPIServiceProtocol {
     } else {
       let response = expectedResponse ?? _GACURLSessionDataResponse(
         response: HTTPURLResponse(),
-        httpBody: Data()
+        httpBody: Data(),
+        requestDate: Date()
       )
       promise.fulfill(response)
     }

--- a/AppCheckRecaptchaProvider/Tests/MockRecaptchaSupport.swift
+++ b/AppCheckRecaptchaProvider/Tests/MockRecaptchaSupport.swift
@@ -111,7 +111,7 @@ class MockAppCheckCoreAPIService: NSObject, _GACAppCheckAPIServiceProtocol {
       let response = expectedResponse ?? _GACURLSessionDataResponse(
         response: HTTPURLResponse(),
         httpBody: Data(),
-        requestDate: Date()
+        request: Date()
       )
       promise.fulfill(response)
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+- [fixed] Fixed an issue where the time-to-live (TTL) for a cached token was calculated from the
+  moment the token response was processed locally, rather than when the request was initiated,
+  which could lead to artificially extended token lifetimes during app suspension.
+  (https://github.com/firebase/firebase-ios-sdk/issues/16573)
+
 # 11.3.1
 - [fixed] Added recovery logic to reset and retry attestation when App Attest
   returns `DCErrorUnknownSystemFailure` during assertion


### PR DESCRIPTION
## Description

Fixes #16573

Previously, `AppCheckCore` counted a cached token's time-to-live starting from the moment the token response was processed locally (`[NSDate date]`). Because we don't trust device clock skew, parsing the JWT `exp` claim directly is undesirable. However, counting from the response processing time introduces a bug where any delay (e.g., app suspension or a stalled thread) between the token request and the response handler executing is silently converted into extra token lifetime.

This PR implements the recommended fix: taking a snapshot of the device timestamp *before* sending the token exchange request, and using that timestamp instead of generating a new one after the response is received.

### Changes
- Updated `_GACURLSessionDataResponse` to capture and store a `requestDate` property.
- Updated `NSURLSession+GACPromises.m` to snapshot `[NSDate date]` right before invoking `dataTaskWithRequest` and passing it to the response object.
- Modified `appCheckTokenWithAPIResponse:` in `GACAppCheckAPIService.m` and `GACAppAttestAPIService.m` to pass down `response.requestDate` to `initWithTokenExchangeResponse:requestDate:error:`.
- Updated all associated unit tests to instantiate `_GACURLSessionDataResponse` with the new `requestDate` initializer correctly.
