### PR TITLE
feat: add in-memory token caching

### DIFF
--- a/AppCheckCore/Sources/Core/GACAppCheck.m
+++ b/AppCheckCore/Sources/Core/GACAppCheck.m
@@ -53,6 +53,8 @@ typedef void (^GACAppCheckTokenHandler)(GACAppCheckTokenResult *result);
 
 @property(nonatomic, nullable) FBLPromise<GACAppCheckToken *> *ongoingRetrieveOrRefreshTokenPromise;
 
+@property(nonatomic, strong, nullable) GACAppCheckToken *inMemoryToken;
+
 @end
 
 @implementation GACAppCheck
@@ -163,11 +165,21 @@ typedef void (^GACAppCheckTokenHandler)(GACAppCheckTokenResult *result);
       });
 }
 
+- (BOOL)isTokenExpiredOrExpiresSoon:(GACAppCheckToken *)token {
+  return [token.expirationDate timeIntervalSinceNow] < kTokenExpirationThreshold;
+}
+
 - (FBLPromise<GACAppCheckToken *> *)getCachedValidTokenForcingRefresh:(BOOL)forcingRefresh {
   if (forcingRefresh) {
+    self.inMemoryToken = nil;
     FBLPromise *rejectedPromise = [FBLPromise pendingPromise];
     [rejectedPromise reject:[_GACAppCheckErrorUtil cachedTokenNotFound]];
     return rejectedPromise;
+  }
+
+  GACAppCheckToken *inMemoryToken = self.inMemoryToken;
+  if (inMemoryToken != nil && ![self isTokenExpiredOrExpiresSoon:inMemoryToken]) {
+    return [FBLPromise resolvedWith:inMemoryToken];
   }
 
   return [self.storage getToken].then(^id(GACAppCheckToken *_Nullable token) {
@@ -175,12 +187,11 @@ typedef void (^GACAppCheckTokenHandler)(GACAppCheckTokenResult *result);
       return [_GACAppCheckErrorUtil cachedTokenNotFound];
     }
 
-    BOOL isTokenExpiredOrExpiresSoon =
-        [token.expirationDate timeIntervalSinceNow] < kTokenExpirationThreshold;
-    if (isTokenExpiredOrExpiresSoon) {
+    if ([self isTokenExpiredOrExpiresSoon:token]) {
       return [_GACAppCheckErrorUtil cachedTokenExpired];
     }
 
+    self.inMemoryToken = token;
     return token;
   });
 }
@@ -191,7 +202,13 @@ typedef void (^GACAppCheckTokenHandler)(GACAppCheckTokenResult *result);
                [self.appCheckProvider getTokenWithCompletion:handler];
              }]
       .then(^id _Nullable(GACAppCheckToken *_Nullable token) {
-        return [self.storage setToken:token];
+        self.inMemoryToken = token;
+        return [self.storage setToken:token].recover(^id _Nullable(NSError *_Nonnull error) {
+          NSString *logMessage =
+              [NSString stringWithFormat:@"Failed to cache App Check token: %@", error];
+          GACAppCheckLogWarning(GACLoggerAppCheckMessageCodeTokenStorageFailed, logMessage);
+          return token;
+        });
       })
       .then(^id _Nullable(GACAppCheckToken *_Nullable token) {
         // TODO: Make sure the self.tokenRefresher is updated only once. Currently the timer will be

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckErrors.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckErrors.h
@@ -46,6 +46,8 @@ typedef NS_ENUM(NSInteger, GACAppCheckMessageCode) {
   // App Check
   GACLoggerAppCheckMessageCodeProviderIsMissing = 2002,
   GACLoggerAppCheckMessageCodeStagingModeEnabled = 2003,
+  /// Failed to cache the App Check token in persistent storage.
+  GACLoggerAppCheckMessageCodeTokenStorageFailed = 2004,
   GACLoggerAppCheckMessageCodeUnexpectedHTTPCode = 3001,
 
   // Debug Provider

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckTests.m
@@ -356,55 +356,228 @@ static NSString *const kAppGroupID = @"app_group_id";
   XCTAssertEqual(self.fakeTokenRefresher.updateWithRefreshResultCallCount, 1);
   XCTAssertEqual(self.fakeTokenDelegate.tokenDidUpdateCallCount, 1);
 
-  // 5. Check a get token call after.
-  [self assertGetToken_WhenCachedTokenIsValid_Success];
+  // 5. Check a get token call after returns the cached token without re-fetching.
+  XCTestExpectation *afterExpectation = [self expectationWithDescription:@"getTokenAfter"];
+  [self.appCheck tokenForcingRefresh:NO
+                          completion:^(GACAppCheckTokenResult *result) {
+                            [afterExpectation fulfill];
+                            XCTAssertEqualObjects(result.token, expectedToken);
+                            XCTAssertNil(result.error);
+                          }];
+  [self waitForExpectations:@[ afterExpectation ] timeout:0.5];
+  XCTAssertEqual(self.fakeAppCheckProvider.getTokenCallCount, 1);
 }
 
 - (void)testGetToken_WhenCalledSeveralTimesError_ThenThereIsOnlyOneOperation {
-  // 1. Expect a token to be requested and stored.
-  NSArray * /*[expectedToken, storeTokenPromise]*/ expectedTokenAndPromise =
-      [self expectTokenRequestFromAppCheckProvider];
-  FBLPromise *storeTokenPromise = expectedTokenAndPromise.lastObject;
+  // 1. Expect a token to be requested from storage, kept pending to merge multiple calls.
+  FBLPromise<GACAppCheckToken *> *storageGetPromise = [FBLPromise pendingPromise];
+  self.fakeStorage.getTokenPromise = storageGetPromise;
 
-  // 1.1. Create an expected error to be reject the store token promise with later.
-  NSError *storageError = [NSError errorWithDomain:self.name code:0 userInfo:nil];
+  // 1.1. Create an expected error to reject the provider request with later.
+  NSError *providerError = [self internalError];
+  self.fakeAppCheckProvider.errorToReturn = providerError;
 
-  // 3. Request token several times.
+  // 2. Request token several times.
   NSInteger getTokenCallsCount = 10;
   NSMutableArray *getTokenCompletionExpectations =
       [NSMutableArray arrayWithCapacity:getTokenCallsCount];
 
   for (NSInteger i = 0; i < getTokenCallsCount; i++) {
-    // 3.1. Expect a completion to be called for each method call.
+    // 2.1. Expect a completion to be called for each method call.
     XCTestExpectation *getTokenExpectation =
         [self expectationWithDescription:[NSString stringWithFormat:@"getToken%@", @(i)]];
     [getTokenCompletionExpectations addObject:getTokenExpectation];
 
-    // 3.2. Request token and verify result.
+    // 2.2. Request token and verify result.
     [self.appCheck tokenForcingRefresh:NO
                             completion:^(GACAppCheckTokenResult *result) {
                               [getTokenExpectation fulfill];
                               XCTAssertEqualObjects(result.token.token, kPlaceholderTokenValue);
                               XCTAssertNotNil(result.error);
-                              XCTAssertNotNil(result.error);
-                              XCTAssertEqualObjects(result.error, storageError);
+                              XCTAssertEqualObjects(result.error, providerError);
                             }];
   }
 
-  // 3.3. Reject the pending promise to finish the get token operation.
-  [storeTokenPromise reject:storageError];
+  // 2.3. Finish storage get with nil so it proceeds to refresh with provider.
+  [storageGetPromise fulfill:nil];
 
-  // 4. Wait for expectations and validate mocks.
+  // 3. Wait for expectations and validate mocks.
   [self waitForExpectations:getTokenCompletionExpectations timeout:0.5];
 
-  // After the first token generation fails and caches the result, the call count will be 1
+  // After the first token generation fails, call count will be 1
   XCTAssertEqual(self.fakeAppCheckProvider.getTokenCallCount, 1);
   XCTAssertEqual(self.fakeTokenDelegate.tokenDidUpdateCallCount, 0);  // No updates on error
-  XCTAssertEqualObjects(self.fakeStorage.lastSetToken, expectedTokenAndPromise.firstObject);
+  XCTAssertNil(self.fakeStorage.lastSetToken);
   XCTAssertEqual(self.fakeTokenRefresher.updateWithRefreshResultCallCount, 0);
 
-  // 5. Check a get token call after.
+  // 4. Check a get token call after.
   [self assertGetToken_WhenCachedTokenIsValid_Success];
+}
+
+- (void)testGetToken_WhenStorageFails_ThenTokenReturnedAndCachedInMemory {
+  // 1. Expect token to be requested from storage (cache miss) and provider to return a valid token.
+  self.fakeStorage.getTokenPromise = [FBLPromise resolvedWith:nil];
+
+  GACAppCheckToken *expectedToken = [self validToken];
+  self.fakeAppCheckProvider.tokenToReturn = expectedToken;
+
+  // 2. Make storage setToken fail with a keychain error.
+  NSError *storageError = [_GACAppCheckErrorUtil keychainErrorWithError:[self internalError]];
+  FBLPromise<GACAppCheckToken *> *rejectedStoragePromise = [FBLPromise pendingPromise];
+  [rejectedStoragePromise reject:storageError];
+  self.fakeStorage.setTokenPromise = rejectedStoragePromise;
+
+  // 3. Request token and verify it succeeds with the valid token despite storage failure.
+  XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
+  [self.appCheck tokenForcingRefresh:NO
+                          completion:^(GACAppCheckTokenResult *result) {
+                            [getTokenExpectation fulfill];
+                            XCTAssertEqualObjects(result.token, expectedToken);
+                            XCTAssertNil(result.error);
+                          }];
+
+  [self waitForExpectations:@[ getTokenExpectation ] timeout:0.5];
+
+  XCTAssertEqual(self.fakeAppCheckProvider.getTokenCallCount, 1);
+  XCTAssertEqualObjects(self.fakeStorage.lastSetToken, expectedToken);
+  XCTAssertEqual(self.fakeTokenRefresher.updateWithRefreshResultCallCount, 1);
+  XCTAssertEqual(self.fakeTokenDelegate.tokenDidUpdateCallCount, 1);
+
+  // 4. Request token again: should be retrieved from in-memory cache without hitting provider or
+  // storage.
+  self.fakeStorage.getTokenPromise = [FBLPromise resolvedWith:nil];
+  XCTestExpectation *cachedExpectation = [self expectationWithDescription:@"getCachedToken"];
+  [self.appCheck tokenForcingRefresh:NO
+                          completion:^(GACAppCheckTokenResult *result) {
+                            [cachedExpectation fulfill];
+                            XCTAssertEqualObjects(result.token, expectedToken);
+                            XCTAssertNil(result.error);
+                          }];
+
+  [self waitForExpectations:@[ cachedExpectation ] timeout:0.5];
+
+  // Provider call count should remain 1.
+  XCTAssertEqual(self.fakeAppCheckProvider.getTokenCallCount, 1);
+}
+
+- (void)testGetToken_WhenForcingRefresh_ThenInMemoryCacheIsBypassed {
+  // 1. Prime the in-memory cache with an initial token.
+  self.fakeStorage.getTokenPromise = [FBLPromise resolvedWith:nil];
+  GACAppCheckToken *token1 = [self validToken];
+  self.fakeAppCheckProvider.tokenToReturn = token1;
+  self.fakeStorage.setTokenPromise = [FBLPromise resolvedWith:token1];
+
+  XCTestExpectation *expectation1 = [self expectationWithDescription:@"getToken1"];
+  [self.appCheck tokenForcingRefresh:NO
+                          completion:^(GACAppCheckTokenResult *result) {
+                            [expectation1 fulfill];
+                            XCTAssertEqualObjects(result.token, token1);
+                            XCTAssertNil(result.error);
+                          }];
+  [self waitForExpectations:@[ expectation1 ] timeout:0.5];
+  XCTAssertEqual(self.fakeAppCheckProvider.getTokenCallCount, 1);
+
+  // 2. Request token with forcingRefresh:YES; should bypass in-memory cache and fetch new token.
+  GACAppCheckToken *token2 = [self validToken];
+  self.fakeAppCheckProvider.tokenToReturn = token2;
+  self.fakeStorage.setTokenPromise = [FBLPromise resolvedWith:token2];
+
+  XCTestExpectation *expectation2 = [self expectationWithDescription:@"getToken2"];
+  [self.appCheck tokenForcingRefresh:YES
+                          completion:^(GACAppCheckTokenResult *result) {
+                            [expectation2 fulfill];
+                            XCTAssertEqualObjects(result.token, token2);
+                            XCTAssertNil(result.error);
+                          }];
+  [self waitForExpectations:@[ expectation2 ] timeout:0.5];
+
+  // Provider call count should now be 2.
+  XCTAssertEqual(self.fakeAppCheckProvider.getTokenCallCount, 2);
+
+  // 3. Subsequent call with forcingRefresh:NO should return token2 from in-memory cache without
+  // calling provider again.
+  XCTestExpectation *expectation3 = [self expectationWithDescription:@"getToken3"];
+  [self.appCheck tokenForcingRefresh:NO
+                          completion:^(GACAppCheckTokenResult *result) {
+                            [expectation3 fulfill];
+                            XCTAssertEqualObjects(result.token, token2);
+                            XCTAssertNil(result.error);
+                          }];
+  [self waitForExpectations:@[ expectation3 ] timeout:0.5];
+  XCTAssertEqual(self.fakeAppCheckProvider.getTokenCallCount, 2);
+}
+
+- (void)testGetToken_WhenForcingRefresh_ThenInMemoryTokenIsInvalidated {
+  // 1. Prime the in-memory cache with an initial token.
+  self.fakeStorage.getTokenPromise = [FBLPromise resolvedWith:nil];
+  GACAppCheckToken *token1 = [self validToken];
+  self.fakeAppCheckProvider.tokenToReturn = token1;
+  self.fakeStorage.setTokenPromise = [FBLPromise resolvedWith:token1];
+
+  XCTestExpectation *expectation1 = [self expectationWithDescription:@"getToken1"];
+  [self.appCheck tokenForcingRefresh:NO
+                          completion:^(GACAppCheckTokenResult *result) {
+                            [expectation1 fulfill];
+                            XCTAssertEqualObjects(result.token, token1);
+                          }];
+  [self waitForExpectations:@[ expectation1 ] timeout:0.5];
+  XCTAssertEqual(self.fakeAppCheckProvider.getTokenCallCount, 1);
+
+  // 2. Force refresh with provider failure.
+  NSError *providerError = [self internalError];
+  self.fakeAppCheckProvider.errorToReturn = providerError;
+  self.fakeAppCheckProvider.tokenToReturn = nil;
+
+  XCTestExpectation *expectation2 = [self expectationWithDescription:@"getToken2"];
+  [self.appCheck tokenForcingRefresh:YES
+                          completion:^(GACAppCheckTokenResult *result) {
+                            [expectation2 fulfill];
+                            XCTAssertEqualObjects(result.error, providerError);
+                          }];
+  [self waitForExpectations:@[ expectation2 ] timeout:0.5];
+  XCTAssertEqual(self.fakeAppCheckProvider.getTokenCallCount, 2);
+
+  // 3. Now request token with forcingRefresh:NO; since token1 was invalidated, it should NOT return
+  // token1. Provider will be called again (or fail).
+  XCTestExpectation *expectation3 = [self expectationWithDescription:@"getToken3"];
+  [self.appCheck tokenForcingRefresh:NO
+                          completion:^(GACAppCheckTokenResult *result) {
+                            [expectation3 fulfill];
+                            XCTAssertEqualObjects(result.error, providerError);
+                          }];
+  [self waitForExpectations:@[ expectation3 ] timeout:0.5];
+  XCTAssertEqual(self.fakeAppCheckProvider.getTokenCallCount, 3);
+}
+
+- (void)testGetToken_WhenInMemoryTokenExpires_ThenRefreshesWithProvider {
+  // 1. Prime the in-memory cache with a soon-expiring token.
+  self.fakeStorage.getTokenPromise = [FBLPromise resolvedWith:nil];
+  GACAppCheckToken *expiringToken = [self soonExpiringToken];
+  self.fakeAppCheckProvider.tokenToReturn = expiringToken;
+  self.fakeStorage.setTokenPromise = [FBLPromise resolvedWith:expiringToken];
+
+  XCTestExpectation *expectation1 = [self expectationWithDescription:@"getToken1"];
+  [self.appCheck tokenForcingRefresh:NO
+                          completion:^(GACAppCheckTokenResult *result) {
+                            [expectation1 fulfill];
+                            XCTAssertEqualObjects(result.token, expiringToken);
+                          }];
+  [self waitForExpectations:@[ expectation1 ] timeout:0.5];
+  XCTAssertEqual(self.fakeAppCheckProvider.getTokenCallCount, 1);
+
+  // 2. Next call with forcingRefresh:NO detects in-memory token expires soon and refreshes.
+  GACAppCheckToken *newToken = [self validToken];
+  self.fakeAppCheckProvider.tokenToReturn = newToken;
+  self.fakeStorage.setTokenPromise = [FBLPromise resolvedWith:newToken];
+
+  XCTestExpectation *expectation2 = [self expectationWithDescription:@"getToken2"];
+  [self.appCheck tokenForcingRefresh:NO
+                          completion:^(GACAppCheckTokenResult *result) {
+                            [expectation2 fulfill];
+                            XCTAssertEqualObjects(result.token, newToken);
+                          }];
+  [self waitForExpectations:@[ expectation2 ] timeout:0.5];
+  XCTAssertEqual(self.fakeAppCheckProvider.getTokenCallCount, 2);
 }
 
 #pragma mark - Helpers

--- a/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -230,6 +230,7 @@ final class AppCheckAPITests {
     case .loggerAppCheckMessageCodeUnknown: break
     case .loggerAppCheckMessageCodeProviderIsMissing: break
     case .loggerAppCheckMessageCodeStagingModeEnabled: break
+    case .loggerAppCheckMessageCodeTokenStorageFailed: break
     case .loggerAppCheckMessageCodeUnexpectedHTTPCode: break
     case .loggerAppCheckMessageLocalDebugToken: break
     case .loggerAppCheckMessageEnvironmentVariableDebugToken: break

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- [changed] Made Keychain token caching errors non-fatal by logging a warning
+  and falling back to an in-memory cache, enabling token retrieval in
+  environments without Keychain access (such as `swift test` and CI).
+
 # 11.3.1
 - [fixed] Added recovery logic to reset and retry attestation when App Attest
   returns `DCErrorUnknownSystemFailure` during assertion


### PR DESCRIPTION
Added an in-memory token cache and made Keychain token caching failures non-fatal in `GACAppCheck`.

Previously, `GACAppCheck.refreshToken` failed the entire token request with `GACAppCheckErrorCodeKeychain` if writing to Keychain storage failed, discarding the valid fetched token. This meant that workflows in environments without Keychain entitlements, such as `swift test` on macOS and CI, were unsupported. Now, tokens are added to an in-memory cache that functions even if writes to Keychain can't be performed and offers faster read times in environments where the Keychain is available.

- **Non-Fatal Storage**: Caught Keychain write errors during `refreshToken`, logged a warning (`GACLoggerAppCheckMessageCodeTokenStorageFailed`), and returned the valid token. Keychain writes are still attempted on every refresh to preserve persistence across cold launches.
- **In-Memory Cache**: Added `inMemoryToken` to `GACAppCheck`. Unexpired tokens are now served directly from memory, eliminating redundant Keychain IPC queries.
- **Forced Refresh Invalidation**: Cleared `inMemoryToken` when `forcingRefresh: YES` was requested so revoked tokens are not retained if a refresh fails.
- **Tests**: Updated and expanded `GACAppCheckTests.m` to cover Keychain write error resilience, in-memory cache hits, forced refresh invalidation, and expiration fallback.

<details>
<summary>Walkthrough - In-Memory Fallback & Non-Fatal Keychain Storage</summary>

We investigated the token caching and Keychain error handling behavior in
`AppCheckCore` and resolved the issue where Keychain write failures (such as
those encountered in `swift test` or un-entitled environments) discarded
valid tokens and failed operations with `GACAppCheckErrorCodeKeychain`.

## Summary of Changes

### [GACAppCheckErrors.h](file:///Volumes/Src-HD/git-repos/app-check/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckErrors.h)
- Added documented message code:
  ```objc
  /// Failed to cache the App Check token in persistent storage.
  GACLoggerAppCheckMessageCodeTokenStorageFailed = 2004,
  ```

### [GACAppCheck.m](file:///Volumes/Src-HD/git-repos/app-check/AppCheckCore/Sources/Core/GACAppCheck.m)
- **In-Memory Cache & Concurrency**:
  - Added `@property(nonatomic, strong, nullable) GACAppCheckToken *inMemoryToken;`.
  - Removed anti-pattern `@synchronized(self)`, relying on queue confinement
    consistent with `ongoingRetrieveOrRefreshTokenPromise` on
    `FBLPromise.defaultDispatchQueue`.
- **Forced Refresh Invalidation**:
  - `getCachedValidTokenForcingRefresh:` explicitly sets `self.inMemoryToken = nil;`
    when `forcingRefresh: YES` is passed. If a token was revoked and a refresh
    fails, the revoked token is no longer retained in memory.
- **Cache Hierarchy (Memory -> Keychain -> Network)**:
  - Checks `inMemoryToken` first via extracted helper `- (BOOL)isTokenExpiredOrExpiresSoon:(GACAppCheckToken *)token`.
  - If absent or expiring within `kTokenExpirationThreshold` (5 min), checks
    Keychain storage.
  - On cache miss, expiration, or Keychain read error, refreshes from the
    provider.
- **Resilient Token Refresh**:
  - In `refreshToken`, `[self.storage setToken:token]` catches Keychain write
    failures with `.recover(^id _Nullable(NSError *_Nonnull error) { ... })`.
  - On failure, logs a warning with message code `2004` and returns the valid
    `token`, allowing the caller to receive the fetched token without failing.
- **Cold Launch Persistence**:
  - Every token refresh continues to attempt persisting to the Keychain,
    preserving persistence across app cold launches in typical environments.
- **Performance Improvement**:
  - Bypassing redundant Keychain IPC (`securityd`) when a valid token is
    already held in memory significantly reduces token retrieval overhead.

### [GACAppCheckTests.m](file:///Volumes/Src-HD/git-repos/app-check/AppCheckCore/Tests/Unit/Core/GACAppCheckTests.m)
- **Operation Merging Tests**:
  - Updated `testGetToken_WhenCalledSeveralTimesError_ThenThereIsOnlyOneOperation`
    to test operation merging on provider failures now that storage failures
    are non-fatal.
  - Updated `testGetToken_WhenCalledSeveralTimesSuccess_ThenThereIsOnlyOneOperation`
    to verify subsequent calls reuse the in-memory cached token.
- **Storage Failure Resilience**:
  - Added `testGetToken_WhenStorageFails_ThenTokenReturnedAndCachedInMemory` to
    verify that Keychain write errors log a warning, succeed with the valid
    token, and cache it in memory.
- **Cache Invalidation & Expiration**:
  - Enhanced `testGetToken_WhenForcingRefresh_ThenInMemoryCacheIsBypassed` to
    verify the refreshed token is served on subsequent calls.
  - Added `testGetToken_WhenForcingRefresh_ThenInMemoryTokenIsInvalidated` to
    verify that `forcingRefresh: YES` invalidates the in-memory token even if
    the refresh fails.
  - Added `testGetToken_WhenInMemoryTokenExpires_ThenRefreshesWithProvider` to
    verify that an expiring in-memory token triggers a refresh.

## Verification Results

### Automated Tests
Ran the full test suite using `swift test` and formatted with `xcsift`:
```bash
swift test 2>&1 | tee /tmp/swift-test.log 2>&1 | /opt/homebrew/bin/xcsift -w -f toon
```

**Output**:
```yaml
status: success
summary:
  errors: 0
  warnings: 0
  failed_tests: 0
  linker_errors: 0
  passed_tests: 136
  build_time: 3.73 secs.
  test_time: 134.286s
```

All 136 unit tests passed with zero errors and zero warnings.

</details>
